### PR TITLE
Add Unit Tests for Equipment Module

### DIFF
--- a/.changeset/cyan-lizards-win.md
+++ b/.changeset/cyan-lizards-win.md
@@ -1,0 +1,5 @@
+---
+'recreation-planner': patch
+---
+
+add unit tests for the equipment data layer and actions

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+max_line_length = 120
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/app/adventure/equipment/[id]/delete/__tests__/action.spec.ts
+++ b/app/adventure/equipment/[id]/delete/__tests__/action.spec.ts
@@ -1,0 +1,57 @@
+import { Equipment } from '@/models';
+import { redirect } from 'next/navigation';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { deleteEquipment } from '../../../data';
+import { deleteAborted, deleteConfirmed } from '../actions';
+
+vi.mock('../../../data');
+vi.mock('next/navigation');
+
+const equipment: Equipment = {
+  id: 42,
+  name: 'Test Kayak',
+  description: 'A kayak for testing',
+  purchaseDate: null,
+  cost: null,
+  manufacturer: null,
+  model: null,
+  identification: null,
+  length: null,
+  weight: null,
+  capacity: null,
+  licensePlateNumber: null,
+  insuranceCarrier: null,
+  insurancePolicyNumber: null,
+  insuranceContactName: null,
+  insuranceContactPhoneNumber: null,
+  insuranceContactEmail: null,
+  equipmentType: { id: 1, name: 'Kayak', description: 'A small boat' },
+};
+
+describe('equipment delete actions', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe('deleteAborted', () => {
+    it('does not call deleteEquipment', async () => {
+      await deleteAborted().catch(() => {});
+      expect(deleteEquipment).not.toHaveBeenCalled();
+    });
+
+    it('redirects to /adventure/equipment', async () => {
+      await deleteAborted().catch(() => {});
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/equipment');
+    });
+  });
+
+  describe('deleteConfirmed', () => {
+    it('calls deleteEquipment with the passed equipment', async () => {
+      await deleteConfirmed(equipment).catch(() => {});
+      expect(deleteEquipment).toHaveBeenCalledExactlyOnceWith(equipment);
+    });
+
+    it('redirects to /adventure/equipment', async () => {
+      await deleteConfirmed(equipment).catch(() => {});
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/equipment');
+    });
+  });
+});

--- a/app/adventure/equipment/[id]/delete/__tests__/action.spec.ts
+++ b/app/adventure/equipment/[id]/delete/__tests__/action.spec.ts
@@ -28,7 +28,7 @@ const equipment: Equipment = {
   equipmentType: { id: 1, name: 'Kayak', description: 'A small boat' },
 };
 
-describe('equipment delete actions', () => {
+describe('equipment: delete actions', () => {
   beforeEach(() => vi.clearAllMocks());
 
   describe('deleteAborted', () => {

--- a/app/adventure/equipment/[id]/maintenance/[maintenanceItemId]/update/__tests__/actions.spec.ts
+++ b/app/adventure/equipment/[id]/maintenance/[maintenanceItemId]/update/__tests__/actions.spec.ts
@@ -1,0 +1,45 @@
+import { MAINTENANCE_ITEMS } from '@/app/adventure/equipment/__mocks__/data';
+import { updateMaintenanceItem } from '@/app/adventure/equipment/data';
+import { MaintenanceItem } from '@/models';
+import { redirect } from 'next/navigation';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { updateConfirmed } from '../actions';
+
+vi.mock('@/app/adventure/equipment/data');
+vi.mock('next/navigation');
+
+const maintenanceItem: MaintenanceItem = {
+  ...MAINTENANCE_ITEMS.find((x) => x.id === 2)!,
+  equipmentRid: 314,
+};
+
+describe('equipment maintenance: updateConfirmed', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('updates the specified maintenance item', async () => {
+    await updateConfirmed(maintenanceItem);
+    expect(updateMaintenanceItem).toHaveBeenCalledExactlyOnceWith(maintenanceItem);
+  });
+
+  describe('on success', () => {
+    beforeEach(() => {
+      (updateMaintenanceItem as any).mockResolvedValue({ ...maintenanceItem });
+    });
+
+    it('redirects to the equipment details page', async () => {
+      await updateConfirmed(maintenanceItem);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/equipment/314?lastActivity=Maintenance');
+    });
+  });
+
+  describe('on failure', () => {
+    beforeEach(() => {
+      (updateMaintenanceItem as any).mockResolvedValue(null);
+    });
+
+    it('redirects to error', async () => {
+      await updateConfirmed(maintenanceItem);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
+    });
+  });
+});

--- a/app/adventure/equipment/[id]/maintenance/create/__tests__/actions.spec.ts
+++ b/app/adventure/equipment/[id]/maintenance/create/__tests__/actions.spec.ts
@@ -1,0 +1,46 @@
+import { MAINTENANCE_ITEMS } from '@/app/adventure/equipment/__mocks__/data';
+import { createConfirmed } from '../actions';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { addMaintenanceItem } from '@/app/adventure/equipment/data';
+import { redirect } from 'next/navigation';
+import { MaintenanceItem } from '@/models';
+
+vi.mock('@/app/adventure/equipment/data');
+vi.mock('next/navigation');
+
+const maintenanceItem: MaintenanceItem = {
+  ...MAINTENANCE_ITEMS.find((x) => x.id === 2)!,
+  equipmentRid: 314,
+  id: undefined,
+};
+
+describe('equipment maintenance: createConfirmed', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('adds the specified maintenance item', async () => {
+    await createConfirmed(maintenanceItem);
+    expect(addMaintenanceItem).toHaveBeenCalledExactlyOnceWith(maintenanceItem);
+  });
+
+  describe('on success', () => {
+    beforeEach(() => {
+      (addMaintenanceItem as any).mockResolvedValue({ ...maintenanceItem, id: 73 });
+    });
+
+    it('redirects to the equipment details page', async () => {
+      await createConfirmed(maintenanceItem);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/equipment/314?lastActivity=Maintenance');
+    });
+  });
+
+  describe('on failure', () => {
+    beforeEach(() => {
+      (addMaintenanceItem as any).mockResolvedValue(null);
+    });
+
+    it('redirects to error', async () => {
+      await createConfirmed(maintenanceItem);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
+    });
+  });
+});

--- a/app/adventure/equipment/[id]/notes/[noteId]/delete/__tests__/actions.spec.ts
+++ b/app/adventure/equipment/[id]/notes/[noteId]/delete/__tests__/actions.spec.ts
@@ -1,25 +1,45 @@
+import { Note } from '@/models';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { deleteAborted, deleteConfirmed } from '../actions';
+import { deleteNote } from '@/app/adventure/notes/data';
+import { redirect } from 'next/navigation';
+
+vi.mock('@/app/adventure/notes/data');
+vi.mock('next/navigation');
+
+const note: Note = {
+  id: 73,
+  name: 'Test Note',
+  description: 'A note for testing',
+  equipmentRid: 42,
+  placeRid: null,
+  eventRid: null,
+};
 
 describe('equipment notes: delete actions', () => {
   beforeEach(() => vi.clearAllMocks());
 
   describe('deleteConfirmed', () => {
-    it('calls deleteNote', () => {
-      expect(true).toBeTruthy();
+    it('calls deleteNote', async () => {
+      await deleteConfirmed(19, note);
+      expect(deleteNote).toHaveBeenCalledExactlyOnceWith(note);
     });
 
-    it('redirects to the equipment details page', () => {
-      expect(true).toBeTruthy();
+    it('redirects to the equipment details page', async () => {
+      await deleteConfirmed(19, note);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/equipment/19?lastActivity=Notes');
     });
   });
 
   describe('deleteAborted', () => {
-    it('does not call deleteNote', () => {
-      expect(true).toBeTruthy();
+    it('does not call deleteNote', async () => {
+      await deleteAborted(19);
+      expect(deleteNote).not.toHaveBeenCalled();
     });
 
-    it('redirects to the equipment details page', () => {
-      expect(true).toBeTruthy();
+    it('redirects to the equipment details page', async () => {
+      await deleteAborted(19);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/equipment/19?lastActivity=Notes');
     });
   });
 });

--- a/app/adventure/equipment/[id]/notes/[noteId]/delete/__tests__/actions.spec.ts
+++ b/app/adventure/equipment/[id]/notes/[noteId]/delete/__tests__/actions.spec.ts
@@ -1,0 +1,25 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('equipment notes: delete actions', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe('deleteConfirmed', () => {
+    it('calls deleteNote', () => {
+      expect(true).toBeTruthy();
+    });
+
+    it('redirects to the equipment details page', () => {
+      expect(true).toBeTruthy();
+    });
+  });
+
+  describe('deleteAborted', () => {
+    it('does not call deleteNote', () => {
+      expect(true).toBeTruthy();
+    });
+
+    it('redirects to the equipment details page', () => {
+      expect(true).toBeTruthy();
+    });
+  });
+});

--- a/app/adventure/equipment/[id]/notes/[noteId]/update/__tests__/actions.spec.ts
+++ b/app/adventure/equipment/[id]/notes/[noteId]/update/__tests__/actions.spec.ts
@@ -24,7 +24,7 @@ describe('equipment notes: updateConfirmed', () => {
     expect(updateNote).toHaveBeenCalledExactlyOnceWith(note);
   });
 
-  describe('when  the update succeeds', () => {
+  describe('when the update succeeds', () => {
     beforeEach(() => {
       (updateNote as any).mockResolvedValue(note);
     });

--- a/app/adventure/equipment/[id]/notes/[noteId]/update/__tests__/actions.spec.ts
+++ b/app/adventure/equipment/[id]/notes/[noteId]/update/__tests__/actions.spec.ts
@@ -1,0 +1,48 @@
+import { updateNote } from '@/app/adventure/notes/data';
+import { Note } from '@/models';
+import { redirect } from 'next/navigation';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { updateConfirmed } from '../actions';
+
+vi.mock('@/app/adventure/notes/data');
+vi.mock('next/navigation');
+
+const note: Note = {
+  id: 73,
+  name: 'Test Note',
+  description: 'A note for testing',
+  equipmentRid: 42,
+  placeRid: null,
+  eventRid: null,
+};
+
+describe('equipment notes: updateConfirmed', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls updateNote with the specified note', async () => {
+    await updateConfirmed(note);
+    expect(updateNote).toHaveBeenCalledExactlyOnceWith(note);
+  });
+
+  describe('when  the update succeeds', () => {
+    beforeEach(() => {
+      (updateNote as any).mockResolvedValue(note);
+    });
+
+    it('redirects to the equipment details page', async () => {
+      await updateConfirmed(note);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/equipment/42?lastActivity=Notes');
+    });
+  });
+
+  describe('when the update fails', () => {
+    beforeEach(() => {
+      (updateNote as any).mockResolvedValue(null);
+    });
+
+    it('redirects to /error', async () => {
+      await updateConfirmed(note);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
+    });
+  });
+});

--- a/app/adventure/equipment/[id]/notes/create/__tests__/actions.spec.ts
+++ b/app/adventure/equipment/[id]/notes/create/__tests__/actions.spec.ts
@@ -1,0 +1,48 @@
+import { Note } from '@/models';
+import { createConfirmed } from '../actions';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { addNote } from '@/app/adventure/notes/data';
+import { redirect } from 'next/navigation';
+
+vi.mock('@/app/adventure/notes/data');
+vi.mock('next/navigation');
+
+const note: Note = {
+  id: 1,
+  name: 'Test Note',
+  description: 'A note for testing',
+  equipmentRid: 42,
+  placeRid: null,
+  eventRid: null,
+};
+
+describe('eqipment note: create', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls addNote with the specified note', async () => {
+    await createConfirmed(note);
+    expect(addNote).toHaveBeenCalledExactlyOnceWith(note);
+  });
+
+  describe('when addNote succeeds', () => {
+    beforeEach(() => {
+      (addNote as any).mockResolvedValue(note);
+    });
+
+    it('redirects to the equipment details page', async () => {
+      await createConfirmed(note);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/equipment/42?lastActivity=Notes');
+    });
+  });
+
+  describe('when addNote fails', () => {
+    beforeEach(() => {
+      (addNote as any).mockResolvedValue(null);
+    });
+
+    it('redirects to /error', async () => {
+      await createConfirmed(note);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
+    });
+  });
+});

--- a/app/adventure/equipment/[id]/notes/create/__tests__/actions.spec.ts
+++ b/app/adventure/equipment/[id]/notes/create/__tests__/actions.spec.ts
@@ -8,7 +8,6 @@ vi.mock('@/app/adventure/notes/data');
 vi.mock('next/navigation');
 
 const note: Note = {
-  id: 1,
   name: 'Test Note',
   description: 'A note for testing',
   equipmentRid: 42,
@@ -26,7 +25,7 @@ describe('eqipment note: create', () => {
 
   describe('when addNote succeeds', () => {
     beforeEach(() => {
-      (addNote as any).mockResolvedValue(note);
+      (addNote as any).mockResolvedValue({ ...note, id: 73 });
     });
 
     it('redirects to the equipment details page', async () => {

--- a/app/adventure/equipment/[id]/notes/create/__tests__/actions.spec.ts
+++ b/app/adventure/equipment/[id]/notes/create/__tests__/actions.spec.ts
@@ -15,7 +15,7 @@ const note: Note = {
   eventRid: null,
 };
 
-describe('eqipment note: create', () => {
+describe('equipment note: create', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('calls addNote with the specified note', async () => {

--- a/app/adventure/equipment/[id]/todos/[collectionId]/delete/__tests__/actions.spec.ts
+++ b/app/adventure/equipment/[id]/todos/[collectionId]/delete/__tests__/actions.spec.ts
@@ -1,0 +1,39 @@
+import { TODO_COLLECTIONS } from '@/app/adventure/todos/__mocks__/data';
+import { deleteTodoCollection } from '@/app/adventure/todos/data';
+import { TodoCollection } from '@/models';
+import { redirect } from 'next/navigation';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { deleteAborted, deleteConfirmed } from '../actions';
+
+vi.mock('@/app/adventure/todos/data');
+vi.mock('next/navigation');
+
+const collection: TodoCollection = { ...TODO_COLLECTIONS.find((x) => x.id === 1)!, equipmentRid: 42 };
+
+describe('equipment TODOs: delete actions', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe('deleteConfirmed', () => {
+    it('calls deleteTodoCollection', async () => {
+      await deleteConfirmed(19, collection);
+      expect(deleteTodoCollection).toHaveBeenCalledExactlyOnceWith(collection);
+    });
+
+    it('redirects to the equipment details page', async () => {
+      await deleteConfirmed(19, collection);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/equipment/19?lastActivity=Todos');
+    });
+  });
+
+  describe('deleteAborted', () => {
+    it('does not call deleteTodoCollection', async () => {
+      await deleteAborted(19);
+      expect(deleteTodoCollection).not.toHaveBeenCalled();
+    });
+
+    it('redirects to the equipment details page', async () => {
+      await deleteAborted(19);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/equipment/19?lastActivity=Todos');
+    });
+  });
+});

--- a/app/adventure/equipment/[id]/todos/[collectionId]/update/__tests__/actions.spec.ts
+++ b/app/adventure/equipment/[id]/todos/[collectionId]/update/__tests__/actions.spec.ts
@@ -1,0 +1,42 @@
+import { TODO_COLLECTIONS } from '@/app/adventure/todos/__mocks__/data';
+import { updateTodoCollection } from '@/app/adventure/todos/data';
+import { TodoCollection } from '@/models';
+import { redirect } from 'next/navigation';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { updateConfirmed } from '../actions';
+
+vi.mock('@/app/adventure/todos/data');
+vi.mock('next/navigation');
+
+const collection: TodoCollection = { ...TODO_COLLECTIONS.find((x) => x.id === 1)!, equipmentRid: 42 };
+
+describe('equipment TODOs: updateConfirmed', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls updateTodoCollection with the passed collection', async () => {
+    await updateConfirmed(collection);
+    expect(updateTodoCollection).toHaveBeenCalledExactlyOnceWith(collection);
+  });
+
+  describe('on success', () => {
+    beforeEach(() => {
+      (updateTodoCollection as any).mockResolvedValue(collection);
+    });
+
+    it('redirects to the equipment details page', async () => {
+      await updateConfirmed(collection);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/equipment/42?lastActivity=Todos');
+    });
+  });
+
+  describe('on failure', () => {
+    beforeEach(() => {
+      (updateTodoCollection as any).mockResolvedValue(null);
+    });
+
+    it('redirects to error', async () => {
+      await updateConfirmed(collection);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
+    });
+  });
+});

--- a/app/adventure/equipment/[id]/todos/create/__tests__/actions.spec.ts
+++ b/app/adventure/equipment/[id]/todos/create/__tests__/actions.spec.ts
@@ -1,0 +1,42 @@
+import { TODO_COLLECTIONS } from '@/app/adventure/todos/__mocks__/data';
+import { addTodoCollection } from '@/app/adventure/todos/data';
+import { TodoCollection } from '@/models';
+import { redirect } from 'next/navigation';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createConfirmed } from '../actions';
+
+vi.mock('@/app/adventure/todos/data');
+vi.mock('next/navigation');
+
+const collection: TodoCollection = { ...TODO_COLLECTIONS.find((x) => x.id === 2)!, id: undefined, equipmentRid: 42 };
+
+describe('equipment todos: createConfirmed', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls addTodoCollection with the specified collection', async () => {
+    await createConfirmed(collection);
+    expect(addTodoCollection).toHaveBeenCalledExactlyOnceWith(collection);
+  });
+
+  describe('on success', () => {
+    beforeEach(() => {
+      (addTodoCollection as any).mockResolvedValue({ ...collection, id: 73 });
+    });
+
+    it('redirects to the equipment details page', async () => {
+      await createConfirmed(collection);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/equipment/42?lastActivity=Todos');
+    });
+  });
+
+  describe('on failure', () => {
+    beforeEach(() => {
+      (addTodoCollection as any).mockResolvedValue(null);
+    });
+
+    it('redirects to error', async () => {
+      await createConfirmed(collection);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
+    });
+  });
+});

--- a/app/adventure/equipment/[id]/update/__tests__/actions.spec.ts
+++ b/app/adventure/equipment/[id]/update/__tests__/actions.spec.ts
@@ -1,0 +1,60 @@
+import { Equipment } from '@/models';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { updateEquipment } from '../../../data';
+import { updateConfirmed } from '../actions';
+import { redirect } from 'next/navigation';
+
+vi.mock('../../../data');
+vi.mock('next/navigation');
+
+const equipment: Equipment = {
+  id: 42,
+  name: 'Test Kayak',
+  description: 'A kayak for testing',
+  purchaseDate: null,
+  cost: null,
+  manufacturer: null,
+  model: null,
+  identification: null,
+  length: null,
+  weight: null,
+  capacity: null,
+  licensePlateNumber: null,
+  insuranceCarrier: null,
+  insurancePolicyNumber: null,
+  insuranceContactName: null,
+  insuranceContactPhoneNumber: null,
+  insuranceContactEmail: null,
+  equipmentType: { id: 1, name: 'Kayak', description: 'A small boat' },
+};
+
+describe('equipment: updateConfirmed', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls updateEquipment with the provided equipment', async () => {
+    await updateConfirmed(equipment).catch(() => {});
+    expect(updateEquipment).toHaveBeenCalledExactlyOnceWith(equipment);
+  });
+
+  describe('when updateEquipment succeeds', () => {
+    beforeEach(() => {
+      (updateEquipment as Mock).mockResolvedValue(equipment);
+    });
+
+    it('redirects to /adventure/equipment', async () => {
+      await updateConfirmed(equipment).catch(() => {});
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/equipment');
+    });
+  });
+
+  describe('when updateEquipment fails', () => {
+    beforeEach(() => {
+      (updateEquipment as Mock).mockResolvedValue(null);
+    });
+
+    it('redirects to /error', async () => {
+      await updateConfirmed(equipment).catch(() => {});
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
+    });
+  });
+});

--- a/app/adventure/equipment/__tests__/data.spec.ts
+++ b/app/adventure/equipment/__tests__/data.spec.ts
@@ -1,0 +1,827 @@
+import { executeQuery } from '@/utils/data';
+import { isNotLoggedIn } from '@/utils/supabase/auth';
+import { createClient } from '@/utils/supabase/server';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import {
+  addEquipment,
+  addMaintenanceItem,
+  canDeleteEquipment,
+  canDeleteMaintenanceItem,
+  deleteEquipment,
+  deleteMaintenanceItem,
+  fetchAllEquipment,
+  fetchEquipment,
+  fetchEquipmentTypes,
+  fetchMaintenanceItem,
+  fetchMaintenanceTypes,
+  fetchUsageUnits,
+  updateEquipment,
+  updateMaintenanceItem,
+} from '../data';
+
+vi.mock('@/utils/supabase/auth');
+vi.mock('@/utils/supabase/server');
+vi.mock('@/utils/data', () => ({ executeQuery: vi.fn() }));
+
+// --- Test data ---
+
+const equipmentTypeDTO = { id: 2, name: 'Automobile', description: 'A car or truck' };
+
+const equipmentDTO = {
+  id: 1,
+  name: 'Test Truck',
+  description: 'A test vehicle',
+  purchase_date: '2014-11-27',
+  cost: 24584.34,
+  manufacturer: 'Ford',
+  model: 'Maverick',
+  identification: 'test-vin',
+  length: null,
+  weight: null,
+  capacity: null,
+  license_plate_number: null,
+  insurance_carrier: null,
+  insurance_policy_number: null,
+  insurance_contact_name: null,
+  insurance_contact_phone_number: null,
+  insurance_contact_email: null,
+  equipment_type_rid: 2,
+  equipment_types: equipmentTypeDTO,
+};
+
+const equipment = {
+  id: 1,
+  name: 'Test Truck',
+  description: 'A test vehicle',
+  purchaseDate: '2014-11-27',
+  cost: 24584.34,
+  manufacturer: 'Ford',
+  model: 'Maverick',
+  identification: 'test-vin',
+  length: null,
+  weight: null,
+  capacity: null,
+  licensePlateNumber: null,
+  insuranceCarrier: null,
+  insurancePolicyNumber: null,
+  insuranceContactName: null,
+  insuranceContactPhoneNumber: null,
+  insuranceContactEmail: null,
+  equipmentType: { id: 2, name: 'Automobile', description: 'A car or truck' },
+};
+
+const maintenanceTypeDTO = { id: 2, name: 'Periodic Maintenance', description: 'Oil change etc.' };
+const usageUnitsDTO = { id: 1, name: 'Miles' };
+
+const maintenanceItemDTO = {
+  id: 5,
+  name: 'Oil Change',
+  description: null,
+  date: '2025-08-15',
+  cost: 123.43,
+  usage: 12834.3,
+  usage_units_rid: 1,
+  usage_units: usageUnitsDTO,
+  maintenance_type_rid: 2,
+  maintenance_types: maintenanceTypeDTO,
+  equipment_rid: 1,
+};
+
+const maintenanceItem = {
+  id: 5,
+  name: 'Oil Change',
+  description: null,
+  date: '2025-08-15',
+  cost: 123.43,
+  usage: 12834.3,
+  usageUnits: { id: 1, name: 'Miles' },
+  maintenanceType: { id: 2, name: 'Periodic Maintenance', description: 'Oil change etc.' },
+  equipmentRid: 1,
+};
+
+// --- Helpers ---
+
+const buildChainableMock = () => {
+  const chain: Record<string, Mock> = {};
+  ['select', 'insert', 'update', 'delete', 'eq', 'single', 'order'].forEach((method) => {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  });
+  return chain;
+};
+
+// --- Tests ---
+
+describe('equipment data', () => {
+  let mockFrom: Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const chain = buildChainableMock();
+    mockFrom = vi.fn().mockReturnValue(chain);
+    vi.mocked(createClient).mockReturnValue({ from: mockFrom } as any);
+  });
+
+  // ---------------------------------------------------------------------------
+  // fetchAllEquipment
+  // ---------------------------------------------------------------------------
+
+  describe('fetchAllEquipment', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns an empty array', async () => {
+        expect(await fetchAllEquipment()).toEqual([]);
+      });
+
+      it('does not access the database', async () => {
+        await fetchAllEquipment();
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue([equipmentDTO]);
+        });
+
+        it('calls executeQuery', async () => {
+          await fetchAllEquipment();
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('queries the equipment table', async () => {
+          await fetchAllEquipment();
+          expect(mockFrom).toHaveBeenCalledWith('equipment');
+        });
+
+        it('returns the converted equipment list', async () => {
+          expect(await fetchAllEquipment()).toEqual([equipment]);
+        });
+      });
+
+      describe('when no data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns an empty array', async () => {
+          expect(await fetchAllEquipment()).toEqual([]);
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // fetchEquipment
+  // ---------------------------------------------------------------------------
+
+  describe('fetchEquipment', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns null', async () => {
+        expect(await fetchEquipment(1)).toBeNull();
+      });
+
+      it('does not access the database', async () => {
+        await fetchEquipment(1);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(equipmentDTO);
+        });
+
+        it('calls executeQuery', async () => {
+          await fetchEquipment(1);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('queries the equipment table', async () => {
+          await fetchEquipment(1);
+          expect(mockFrom).toHaveBeenCalledWith('equipment');
+        });
+
+        it('returns the converted equipment', async () => {
+          expect(await fetchEquipment(1)).toEqual(equipment);
+        });
+      });
+
+      describe('when no data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns null', async () => {
+          expect(await fetchEquipment(1)).toBeNull();
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // addEquipment
+  // ---------------------------------------------------------------------------
+
+  describe('addEquipment', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns null', async () => {
+        expect(await addEquipment(equipment)).toBeNull();
+      });
+
+      it('does not access the database', async () => {
+        await addEquipment(equipment);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when the insert succeeds', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(equipmentDTO);
+        });
+
+        it('calls executeQuery', async () => {
+          await addEquipment(equipment);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('inserts into the equipment table', async () => {
+          await addEquipment(equipment);
+          expect(mockFrom).toHaveBeenCalledWith('equipment');
+        });
+
+        it('returns the converted equipment', async () => {
+          expect(await addEquipment(equipment)).toEqual(equipment);
+        });
+      });
+
+      describe('when the insert fails', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns null', async () => {
+          expect(await addEquipment(equipment)).toBeNull();
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // canDeleteEquipment
+  // ---------------------------------------------------------------------------
+
+  describe('canDeleteEquipment', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns false', async () => {
+        expect(await canDeleteEquipment(equipment)).toBe(false);
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      it('returns true', async () => {
+        expect(await canDeleteEquipment(equipment)).toBe(true);
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // deleteEquipment
+  // ---------------------------------------------------------------------------
+
+  describe('deleteEquipment', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('does not access the database', async () => {
+        await deleteEquipment(equipment);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+        (executeQuery as Mock).mockResolvedValue(null);
+      });
+
+      it('calls executeQuery', async () => {
+        await deleteEquipment(equipment);
+        expect(executeQuery).toHaveBeenCalledOnce();
+      });
+
+      it('deletes from the equipment table', async () => {
+        await deleteEquipment(equipment);
+        expect(mockFrom).toHaveBeenCalledWith('equipment');
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // updateEquipment
+  // ---------------------------------------------------------------------------
+
+  describe('updateEquipment', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns null', async () => {
+        expect(await updateEquipment(equipment)).toBeNull();
+      });
+
+      it('does not access the database', async () => {
+        await updateEquipment(equipment);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when the update succeeds', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(equipmentDTO);
+        });
+
+        it('calls executeQuery', async () => {
+          await updateEquipment(equipment);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('updates the equipment table', async () => {
+          await updateEquipment(equipment);
+          expect(mockFrom).toHaveBeenCalledWith('equipment');
+        });
+
+        it('returns the converted equipment', async () => {
+          expect(await updateEquipment(equipment)).toEqual(equipment);
+        });
+      });
+
+      describe('when the update fails', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns null', async () => {
+          expect(await updateEquipment(equipment)).toBeNull();
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // fetchEquipmentTypes
+  // ---------------------------------------------------------------------------
+
+  describe('fetchEquipmentTypes', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns an empty array', async () => {
+        expect(await fetchEquipmentTypes()).toEqual([]);
+      });
+
+      it('does not access the database', async () => {
+        await fetchEquipmentTypes();
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue([equipmentTypeDTO]);
+        });
+
+        it('calls executeQuery', async () => {
+          await fetchEquipmentTypes();
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('queries the equipment_types table', async () => {
+          await fetchEquipmentTypes();
+          expect(mockFrom).toHaveBeenCalledWith('equipment_types');
+        });
+
+        it('returns the converted equipment types', async () => {
+          expect(await fetchEquipmentTypes()).toEqual([{ id: 2, name: 'Automobile', description: 'A car or truck' }]);
+        });
+      });
+
+      describe('when no data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns an empty array', async () => {
+          expect(await fetchEquipmentTypes()).toEqual([]);
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // fetchMaintenanceItem
+  // ---------------------------------------------------------------------------
+
+  describe('fetchMaintenanceItem', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns null', async () => {
+        expect(await fetchMaintenanceItem(5)).toBeNull();
+      });
+
+      it('does not access the database', async () => {
+        await fetchMaintenanceItem(5);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(maintenanceItemDTO);
+        });
+
+        it('calls executeQuery', async () => {
+          await fetchMaintenanceItem(5);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('queries the maintenance_items table', async () => {
+          await fetchMaintenanceItem(5);
+          expect(mockFrom).toHaveBeenCalledWith('maintenance_items');
+        });
+
+        it('returns the converted maintenance item', async () => {
+          expect(await fetchMaintenanceItem(5)).toEqual(maintenanceItem);
+        });
+      });
+
+      describe('when no data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns null', async () => {
+          expect(await fetchMaintenanceItem(5)).toBeNull();
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // addMaintenanceItem
+  // ---------------------------------------------------------------------------
+
+  describe('addMaintenanceItem', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns null', async () => {
+        expect(await addMaintenanceItem(maintenanceItem)).toBeNull();
+      });
+
+      it('does not access the database', async () => {
+        await addMaintenanceItem(maintenanceItem);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when the insert succeeds', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(maintenanceItemDTO);
+        });
+
+        it('calls executeQuery', async () => {
+          await addMaintenanceItem(maintenanceItem);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('inserts into the maintenance_items table', async () => {
+          await addMaintenanceItem(maintenanceItem);
+          expect(mockFrom).toHaveBeenCalledWith('maintenance_items');
+        });
+
+        it('returns the converted maintenance item', async () => {
+          expect(await addMaintenanceItem(maintenanceItem)).toEqual(maintenanceItem);
+        });
+      });
+
+      describe('when the insert fails', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns null', async () => {
+          expect(await addMaintenanceItem(maintenanceItem)).toBeNull();
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // canDeleteMaintenanceItem
+  // ---------------------------------------------------------------------------
+
+  describe('canDeleteMaintenanceItem', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns false', async () => {
+        expect(await canDeleteMaintenanceItem(maintenanceItem)).toBe(false);
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      it('returns true', async () => {
+        expect(await canDeleteMaintenanceItem(maintenanceItem)).toBe(true);
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // deleteMaintenanceItem
+  // ---------------------------------------------------------------------------
+
+  describe('deleteMaintenanceItem', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('does not access the database', async () => {
+        await deleteMaintenanceItem(maintenanceItem);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+        (executeQuery as Mock).mockResolvedValue(null);
+      });
+
+      it('calls executeQuery', async () => {
+        await deleteMaintenanceItem(maintenanceItem);
+        expect(executeQuery).toHaveBeenCalledOnce();
+      });
+
+      it('deletes from the maintenance_items table', async () => {
+        await deleteMaintenanceItem(maintenanceItem);
+        expect(mockFrom).toHaveBeenCalledWith('maintenance_items');
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // updateMaintenanceItem
+  // ---------------------------------------------------------------------------
+
+  describe('updateMaintenanceItem', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns null', async () => {
+        expect(await updateMaintenanceItem(maintenanceItem)).toBeNull();
+      });
+
+      it('does not access the database', async () => {
+        await updateMaintenanceItem(maintenanceItem);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when the update succeeds', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(maintenanceItemDTO);
+        });
+
+        it('calls executeQuery', async () => {
+          await updateMaintenanceItem(maintenanceItem);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('updates the maintenance_items table', async () => {
+          await updateMaintenanceItem(maintenanceItem);
+          expect(mockFrom).toHaveBeenCalledWith('maintenance_items');
+        });
+
+        it('returns the converted maintenance item', async () => {
+          expect(await updateMaintenanceItem(maintenanceItem)).toEqual(maintenanceItem);
+        });
+      });
+
+      describe('when the update fails', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns null', async () => {
+          expect(await updateMaintenanceItem(maintenanceItem)).toBeNull();
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // fetchMaintenanceTypes
+  // ---------------------------------------------------------------------------
+
+  describe('fetchMaintenanceTypes', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns an empty array', async () => {
+        expect(await fetchMaintenanceTypes()).toEqual([]);
+      });
+
+      it('does not access the database', async () => {
+        await fetchMaintenanceTypes();
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue([maintenanceTypeDTO]);
+        });
+
+        it('calls executeQuery', async () => {
+          await fetchMaintenanceTypes();
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('queries the maintenance_types table', async () => {
+          await fetchMaintenanceTypes();
+          expect(mockFrom).toHaveBeenCalledWith('maintenance_types');
+        });
+
+        it('returns the converted maintenance types', async () => {
+          expect(await fetchMaintenanceTypes()).toEqual([
+            { id: 2, name: 'Periodic Maintenance', description: 'Oil change etc.' },
+          ]);
+        });
+      });
+
+      describe('when no data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns an empty array', async () => {
+          expect(await fetchMaintenanceTypes()).toEqual([]);
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // fetchUsageUnits
+  // ---------------------------------------------------------------------------
+
+  describe('fetchUsageUnits', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns an empty array', async () => {
+        expect(await fetchUsageUnits()).toEqual([]);
+      });
+
+      it('does not access the database', async () => {
+        await fetchUsageUnits();
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue([usageUnitsDTO]);
+        });
+
+        it('calls executeQuery', async () => {
+          await fetchUsageUnits();
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('queries the usage_units table', async () => {
+          await fetchUsageUnits();
+          expect(mockFrom).toHaveBeenCalledWith('usage_units');
+        });
+
+        it('returns the converted usage units', async () => {
+          expect(await fetchUsageUnits()).toEqual([{ id: 1, name: 'Miles' }]);
+        });
+      });
+
+      describe('when no data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns an empty array', async () => {
+          expect(await fetchUsageUnits()).toEqual([]);
+        });
+      });
+    });
+  });
+});

--- a/app/adventure/equipment/create/__tests__/actions.spec.ts
+++ b/app/adventure/equipment/create/__tests__/actions.spec.ts
@@ -28,7 +28,7 @@ const equipment: Equipment = {
   equipmentType: { id: 1, name: 'Kayak', description: 'A small boat' },
 };
 
-describe('createEquipmentConfirmed', () => {
+describe('equipment: createEquipmentConfirmed', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('calls addEquipment with the provided equipment', async () => {

--- a/app/adventure/equipment/create/__tests__/actions.spec.ts
+++ b/app/adventure/equipment/create/__tests__/actions.spec.ts
@@ -1,0 +1,60 @@
+import { Equipment } from '@/models';
+import { redirect } from 'next/navigation';
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { addEquipment } from '../../data';
+import { createEquipmentConfirmed } from '../actions';
+
+vi.mock('../../data');
+vi.mock('next/navigation');
+
+const equipment: Equipment = {
+  id: 0,
+  name: 'Test Kayak',
+  description: 'A kayak for testing',
+  purchaseDate: null,
+  cost: null,
+  manufacturer: null,
+  model: null,
+  identification: null,
+  length: null,
+  weight: null,
+  capacity: null,
+  licensePlateNumber: null,
+  insuranceCarrier: null,
+  insurancePolicyNumber: null,
+  insuranceContactName: null,
+  insuranceContactPhoneNumber: null,
+  insuranceContactEmail: null,
+  equipmentType: { id: 1, name: 'Kayak', description: 'A small boat' },
+};
+
+describe('createEquipmentConfirmed', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls addEquipment with the provided equipment', async () => {
+    await createEquipmentConfirmed(equipment).catch(() => {});
+    expect(addEquipment).toHaveBeenCalledExactlyOnceWith(equipment);
+  });
+
+  describe('when addEquipment succeeds', () => {
+    beforeEach(() => {
+      (addEquipment as Mock).mockResolvedValue({ ...equipment, id: 42 });
+    });
+
+    it('redirects to /adventure/equipment', async () => {
+      await createEquipmentConfirmed(equipment).catch(() => {});
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/equipment');
+    });
+  });
+
+  describe('when addEquipment fails', () => {
+    beforeEach(() => {
+      (addEquipment as Mock).mockResolvedValue(null);
+    });
+
+    it('redirects to /error', async () => {
+      await createEquipmentConfirmed(equipment).catch(() => {});
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
+    });
+  });
+});


### PR DESCRIPTION
This pull request introduces comprehensive unit tests for the equipment management module.

### Key Changes:
- **Equipment Data Layer:** Implements tests for data access functions related to equipment, maintenance items, and associated types, ensuring robust interactions with the database.
- **Action Handlers:** Adds tests for action functions covering create, update, and delete operations for:
    - Main equipment records
    - Equipment maintenance items
    - Equipment-specific notes
    - Equipment-related TODO collections
- **Code Style Consistency:** Includes an `.editorconfig` file to standardize code formatting across the project, promoting readability and maintainability.

These tests enhance the stability and reliability of the equipment module by verifying critical business logic and data persistence operations.

Relates to #20