### PR TITLE
Add tests for places data and actions

### DIFF
--- a/.changeset/honest-coats-punch.md
+++ b/.changeset/honest-coats-punch.md
@@ -1,0 +1,5 @@
+---
+'recreation-planner': patch
+---
+
+add tests for the places data layer and actions

--- a/app/adventure/places/[id]/delete/__tests__/actions.spec.ts
+++ b/app/adventure/places/[id]/delete/__tests__/actions.spec.ts
@@ -1,0 +1,39 @@
+import { Place } from '@/models';
+import { PLACES } from '@/app/adventure/places/__mocks__/data';
+import { redirect } from 'next/navigation';
+import { describe, beforeEach, vi, it, expect } from 'vitest';
+import { deleteConfirmed, deleteAborted } from '../actions';
+import { deletePlace } from '@/app/adventure/places/data';
+
+vi.mock('@/app/adventure/places/data');
+vi.mock('next/navigation');
+
+const place: Place = PLACES.find((p) => p.id === 2)!;
+
+describe('places: delete actions', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe('deleteConfirmed', () => {
+    it('calls deletePlace', async () => {
+      await deleteConfirmed(place);
+      expect(deletePlace).toHaveBeenCalledExactlyOnceWith(place);
+    });
+
+    it('redirects to the places list page', async () => {
+      await deleteConfirmed(place);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/places');
+    });
+  });
+
+  describe('deleteAborted', () => {
+    it('does not call deletePlace', async () => {
+      await deleteAborted();
+      expect(deletePlace).not.toHaveBeenCalled();
+    });
+
+    it('redirects to the places list page', async () => {
+      await deleteAborted();
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/places');
+    });
+  });
+});

--- a/app/adventure/places/[id]/notes/[noteId]/delete/__tests__/actions.spec.ts
+++ b/app/adventure/places/[id]/notes/[noteId]/delete/__tests__/actions.spec.ts
@@ -1,0 +1,39 @@
+import { NOTES } from '@/app/adventure/notes/__mocks__/data';
+import { Note } from '@/models';
+import { redirect } from 'next/navigation';
+import { describe, beforeEach, vi, it, expect } from 'vitest';
+import { deleteConfirmed, deleteAborted } from '../actions';
+import { deleteNote } from '@/app/adventure/notes/data';
+
+vi.mock('@/app/adventure/notes/data');
+vi.mock('next/navigation');
+
+const note: Note = { ...NOTES.find((n) => n.placeRid !== null)!, placeRid: 314 };
+
+describe('place notes: delete actions', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe('deleteConfirmed', () => {
+    it('calls deleteNote', async () => {
+      await deleteConfirmed(19, note);
+      expect(deleteNote).toHaveBeenCalledExactlyOnceWith(note);
+    });
+
+    it('redirects to the place details page', async () => {
+      await deleteConfirmed(19, note);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/places/19');
+    });
+  });
+
+  describe('deleteAborted', () => {
+    it('does not call deleteNote', async () => {
+      await deleteAborted(19);
+      expect(deleteNote).not.toHaveBeenCalled();
+    });
+
+    it('redirects to the place details page', async () => {
+      await deleteAborted(19);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/places/19');
+    });
+  });
+});

--- a/app/adventure/places/[id]/notes/[noteId]/update/__tests__/actions.spec.ts
+++ b/app/adventure/places/[id]/notes/[noteId]/update/__tests__/actions.spec.ts
@@ -1,0 +1,42 @@
+import { NOTES } from '@/app/adventure/notes/__mocks__/data';
+import { updateNote } from '@/app/adventure/notes/data';
+import { Note } from '@/models';
+import { redirect } from 'next/navigation';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { updateConfirmed } from '../actions';
+
+vi.mock('@/app/adventure/notes/data');
+vi.mock('next/navigation');
+
+const note: Note = { ...NOTES.find((n) => n.placeRid !== null)!, placeRid: 14 };
+
+describe('place notes: updateConfirmed', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls updateNote with the specified note', async () => {
+    await updateConfirmed(note);
+    expect(updateNote).toHaveBeenCalledExactlyOnceWith(note);
+  });
+
+  describe('when updateNote succeeds', () => {
+    beforeEach(() => {
+      (updateNote as any).mockResolvedValue(note);
+    });
+
+    it('redirects to the place details page', async () => {
+      await updateConfirmed(note);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/places/14');
+    });
+  });
+
+  describe('when updateNote fails', () => {
+    beforeEach(() => {
+      (updateNote as any).mockResolvedValue(null);
+    });
+
+    it('redirects to /error', async () => {
+      await updateConfirmed(note);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
+    });
+  });
+});

--- a/app/adventure/places/[id]/notes/create/__tests__/actions.spec.ts
+++ b/app/adventure/places/[id]/notes/create/__tests__/actions.spec.ts
@@ -1,0 +1,42 @@
+import { NOTES } from '@/app/adventure/notes/__mocks__/data';
+import { Note } from '@/models';
+import { describe, beforeEach, vi, it, expect } from 'vitest';
+import { createConfirmed } from '../actions';
+import { addNote } from '@/app/adventure/notes/data';
+import { redirect } from 'next/navigation';
+
+vi.mock('@/app/adventure/notes/data');
+vi.mock('next/navigation');
+
+const note: Note = { ...NOTES.find((n) => n.placeRid !== null)!, id: undefined, placeRid: 19 };
+
+describe('place notes: createConfirmed', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls addNote with the specified note', async () => {
+    await createConfirmed(note);
+    expect(addNote).toHaveBeenCalledExactlyOnceWith(note);
+  });
+
+  describe('when addNote succeeds', () => {
+    beforeEach(() => {
+      (addNote as any).mockResolvedValue({ ...note, id: 73 });
+    });
+
+    it('redirects to the place details page', async () => {
+      await createConfirmed(note);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/places/19');
+    });
+  });
+
+  describe('when addNote fails', () => {
+    beforeEach(() => {
+      (addNote as any).mockResolvedValue(null);
+    });
+
+    it('redirects to /error', async () => {
+      await createConfirmed(note);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
+    });
+  });
+});

--- a/app/adventure/places/[id]/update/__tests__/actions.spec.ts
+++ b/app/adventure/places/[id]/update/__tests__/actions.spec.ts
@@ -20,7 +20,7 @@ describe('places: updateConfirmed', () => {
 
   describe('when the update succeeds', () => {
     beforeEach(() => {
-      (updatePlace as any).mockResolvedValue(true);
+      (updatePlace as any).mockResolvedValue(place);
     });
 
     it('redirects to the places list page', async () => {

--- a/app/adventure/places/[id]/update/__tests__/actions.spec.ts
+++ b/app/adventure/places/[id]/update/__tests__/actions.spec.ts
@@ -1,0 +1,42 @@
+import { PLACES } from '@/app/adventure/places/__mocks__/data';
+import { updatePlace } from '@/app/adventure/places/data';
+import { Place } from '@/models';
+import { redirect } from 'next/navigation';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { updateConfirmed } from '../actions';
+
+vi.mock('@/app/adventure/places/data');
+vi.mock('next/navigation');
+
+const place: Place = PLACES.find((p) => p.id === 2)!;
+
+describe('places: updateConfirmed', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls updatePlace with the specified place', async () => {
+    await updateConfirmed(place);
+    expect(updatePlace).toHaveBeenCalledExactlyOnceWith(place);
+  });
+
+  describe('when the update succeeds', () => {
+    beforeEach(() => {
+      (updatePlace as any).mockResolvedValue(true);
+    });
+
+    it('redirects to the places list page', async () => {
+      await updateConfirmed(place);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/places');
+    });
+  });
+
+  describe('when the update fails', () => {
+    beforeEach(() => {
+      (updatePlace as any).mockResolvedValue(null);
+    });
+
+    it('redirects to /error', async () => {
+      await updateConfirmed(place);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
+    });
+  });
+});

--- a/app/adventure/places/__tests__/data.spec.ts
+++ b/app/adventure/places/__tests__/data.spec.ts
@@ -179,7 +179,7 @@ describe('places data', () => {
 
       describe('when data is returned', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(placeDTO);
+          (executeQuery as Mock).mockResolvedValue(full ? placeWithNotesDTO : placeDTO);
         });
 
         it('calls executeQuery', async () => {
@@ -193,24 +193,7 @@ describe('places data', () => {
         });
 
         it('returns the converted place', async () => {
-          expect(await fetchPlace(1, full)).toEqual(place);
-        });
-      });
-
-      describe('when full data is requested', () => {
-        it('returns the converted place with notes', async () => {
-          (executeQuery as Mock).mockResolvedValue(placeWithNotesDTO);
-          expect(await fetchPlace(1, true)).toEqual(placeWithNotes);
-        });
-
-        it('returns null when no full data is returned', async () => {
-          (executeQuery as Mock).mockResolvedValue(null);
-          expect(await fetchPlace(1, true)).toBeNull();
-        });
-
-        it('throws when full query execution fails', async () => {
-          (executeQuery as Mock).mockRejectedValue(new Error('database error'));
-          await expect(fetchPlace(1, true)).rejects.toThrow('database error');
+          expect(await fetchPlace(1, full)).toEqual(full ? placeWithNotes : place);
         });
       });
 

--- a/app/adventure/places/__tests__/data.spec.ts
+++ b/app/adventure/places/__tests__/data.spec.ts
@@ -1,0 +1,456 @@
+import { executeQuery } from '@/utils/data';
+import { isNotLoggedIn } from '@/utils/supabase/auth';
+import { createClient } from '@/utils/supabase/server';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { addPlace, canDeletePlace, deletePlace, fetchPlace, fetchPlaces, fetchPlaceTypes, updatePlace } from '../data';
+
+vi.mock('@/utils/supabase/auth');
+vi.mock('@/utils/supabase/server');
+vi.mock('@/utils/data', () => ({ executeQuery: vi.fn() }));
+
+// --- Test data ---
+
+const placeTypeDTO = { id: 3, name: 'Campground', description: 'A place to camp' };
+
+const placeDTO = {
+  id: 1,
+  name: 'Test Campground',
+  description: 'A test campground',
+  address_line_1: '123 Main St',
+  address_line_2: null,
+  city: 'Anytown',
+  state: 'CA',
+  postal_code: '12345',
+  phone_number: '555-555-5555',
+  website: 'https://example.com',
+  place_type_rid: 3,
+  place_types: placeTypeDTO,
+};
+
+const place = {
+  id: 1,
+  name: 'Test Campground',
+  description: 'A test campground',
+  address: {
+    line1: '123 Main St',
+    line2: null,
+    city: 'Anytown',
+    state: 'CA',
+    postal: '12345',
+  },
+  phoneNumber: '555-555-5555',
+  website: 'https://example.com',
+  type: { id: 3, name: 'Campground', description: 'A place to camp' },
+};
+
+// --- Helpers ---
+
+const buildChainableMock = () => {
+  const chain: Record<string, Mock> = {};
+  ['select', 'insert', 'update', 'delete', 'eq', 'single', 'order'].forEach((method) => {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  });
+  return chain;
+};
+
+// --- Tests ---
+
+describe('places data', () => {
+  let mockFrom: Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const chain = buildChainableMock();
+    mockFrom = vi.fn().mockReturnValue(chain);
+    vi.mocked(createClient).mockReturnValue({ from: mockFrom } as any);
+  });
+
+  // ---------------------------------------------------------------------------
+  // fetchPlaces
+  // ---------------------------------------------------------------------------
+
+  describe('fetchPlaces', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns an empty array', async () => {
+        expect(await fetchPlaces()).toEqual([]);
+      });
+
+      it('does not access the database', async () => {
+        await fetchPlaces();
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue([placeDTO]);
+        });
+
+        it('calls executeQuery', async () => {
+          await fetchPlaces();
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('queries the places table', async () => {
+          await fetchPlaces();
+          expect(mockFrom).toHaveBeenCalledWith('places');
+        });
+
+        it('returns the converted places list', async () => {
+          expect(await fetchPlaces()).toEqual([place]);
+        });
+      });
+
+      describe('when no data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns an empty array', async () => {
+          expect(await fetchPlaces()).toEqual([]);
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // fetchPlace
+  // ---------------------------------------------------------------------------
+
+  describe('fetchPlace', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns null', async () => {
+        expect(await fetchPlace(1)).toBeNull();
+      });
+
+      it('does not access the database', async () => {
+        await fetchPlace(1);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(placeDTO);
+        });
+
+        it('calls executeQuery', async () => {
+          await fetchPlace(1);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('queries the places table', async () => {
+          await fetchPlace(1);
+          expect(mockFrom).toHaveBeenCalledWith('places');
+        });
+
+        it('returns the converted place', async () => {
+          expect(await fetchPlace(1)).toEqual(place);
+        });
+      });
+
+      describe('when no data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns null', async () => {
+          expect(await fetchPlace(1)).toBeNull();
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // addPlace
+  // ---------------------------------------------------------------------------
+
+  describe('addPlace', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns null', async () => {
+        expect(await addPlace(place as any)).toBeNull();
+      });
+
+      it('does not access the database', async () => {
+        await addPlace(place as any);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when the insert succeeds', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(placeDTO);
+        });
+
+        it('calls executeQuery', async () => {
+          await addPlace(place as any);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('inserts into the places table', async () => {
+          await addPlace(place as any);
+          expect(mockFrom).toHaveBeenCalledWith('places');
+        });
+
+        it('returns the converted place', async () => {
+          expect(await addPlace(place as any)).toEqual(place);
+        });
+      });
+
+      describe('when the insert fails', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns null', async () => {
+          expect(await addPlace(place as any)).toBeNull();
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // fetchPlaceTypes
+  // ---------------------------------------------------------------------------
+
+  describe('fetchPlaceTypes', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns an empty array', async () => {
+        expect(await fetchPlaceTypes()).toEqual([]);
+      });
+
+      it('does not access the database', async () => {
+        await fetchPlaceTypes();
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue([placeTypeDTO]);
+        });
+
+        it('calls executeQuery', async () => {
+          await fetchPlaceTypes();
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('queries the place_types table', async () => {
+          await fetchPlaceTypes();
+          expect(mockFrom).toHaveBeenCalledWith('place_types');
+        });
+
+        it('returns the place types', async () => {
+          expect(await fetchPlaceTypes()).toEqual([{ id: 3, name: 'Campground', description: 'A place to camp' }]);
+        });
+      });
+
+      describe('when no data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns an empty array', async () => {
+          expect(await fetchPlaceTypes()).toEqual([]);
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // canDeletePlace
+  // ---------------------------------------------------------------------------
+
+  describe('canDeletePlace', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns false', async () => {
+        expect(await canDeletePlace(place as any)).toBe(false);
+      });
+
+      it('does not access the database', async () => {
+        await canDeletePlace(place as any);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      it('queries the events table', async () => {
+        (executeQuery as Mock).mockResolvedValue({ count: 0 });
+        await canDeletePlace(place as any);
+        expect(mockFrom).toHaveBeenCalledWith('events');
+      });
+
+      describe('when the place is not used in any events', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue({ count: 0 });
+        });
+
+        it('returns true', async () => {
+          expect(await canDeletePlace(place as any)).toBe(true);
+        });
+      });
+
+      describe('when the place is used in one or more events', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue({ count: 3 });
+        });
+
+        it('returns false', async () => {
+          expect(await canDeletePlace(place as any)).toBe(false);
+        });
+      });
+
+      describe('when the query returns no data', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns false', async () => {
+          expect(await canDeletePlace(place as any)).toBe(false);
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // deletePlace
+  // ---------------------------------------------------------------------------
+
+  describe('deletePlace', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('does not access the database', async () => {
+        await deletePlace(place as any);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+        (executeQuery as Mock).mockResolvedValue(null);
+      });
+
+      it('calls executeQuery', async () => {
+        await deletePlace(place as any);
+        expect(executeQuery).toHaveBeenCalledOnce();
+      });
+
+      it('deletes from the places table', async () => {
+        await deletePlace(place as any);
+        expect(mockFrom).toHaveBeenCalledWith('places');
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // updatePlace
+  // ---------------------------------------------------------------------------
+
+  describe('updatePlace', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns null', async () => {
+        expect(await updatePlace(place as any)).toBeNull();
+      });
+
+      it('does not access the database', async () => {
+        await updatePlace(place as any);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when the update succeeds', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(placeDTO);
+        });
+
+        it('calls executeQuery', async () => {
+          await updatePlace(place as any);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('updates the places table', async () => {
+          await updatePlace(place as any);
+          expect(mockFrom).toHaveBeenCalledWith('places');
+        });
+
+        it('returns the converted place', async () => {
+          expect(await updatePlace(place as any)).toEqual(place);
+        });
+      });
+
+      describe('when the update fails', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns null', async () => {
+          expect(await updatePlace(place as any)).toBeNull();
+        });
+      });
+    });
+  });
+});

--- a/app/adventure/places/__tests__/data.spec.ts
+++ b/app/adventure/places/__tests__/data.spec.ts
@@ -27,6 +27,20 @@ const placeDTO = {
   place_types: placeTypeDTO,
 };
 
+const placeWithNotesDTO = {
+  ...placeDTO,
+  notes: [
+    {
+      id: 8,
+      name: 'Bring firewood',
+      description: 'Check local restrictions',
+      place_rid: 1,
+      equipment_rid: null,
+      event_rid: null,
+    },
+  ],
+};
+
 const place = {
   id: 1,
   name: 'Test Campground',
@@ -41,6 +55,20 @@ const place = {
   phoneNumber: '555-555-5555',
   website: 'https://example.com',
   type: { id: 3, name: 'Campground', description: 'A place to camp' },
+};
+
+const placeWithNotes = {
+  ...place,
+  notes: [
+    {
+      id: 8,
+      name: 'Bring firewood',
+      description: 'Check local restrictions',
+      placeRid: 1,
+      equipmentRid: null,
+      eventRid: null,
+    },
+  ],
 };
 
 // --- Helpers ---
@@ -166,6 +194,23 @@ describe('places data', () => {
 
         it('returns the converted place', async () => {
           expect(await fetchPlace(1)).toEqual(place);
+        });
+      });
+
+      describe('when full data is requested', () => {
+        it('returns the converted place with notes', async () => {
+          (executeQuery as Mock).mockResolvedValue(placeWithNotesDTO);
+          expect(await fetchPlace(1, true)).toEqual(placeWithNotes);
+        });
+
+        it('returns null when no full data is returned', async () => {
+          (executeQuery as Mock).mockResolvedValue(null);
+          expect(await fetchPlace(1, true)).toBeNull();
+        });
+
+        it('throws when full query execution fails', async () => {
+          (executeQuery as Mock).mockRejectedValue(new Error('database error'));
+          await expect(fetchPlace(1, true)).rejects.toThrow('database error');
         });
       });
 

--- a/app/adventure/places/__tests__/data.spec.ts
+++ b/app/adventure/places/__tests__/data.spec.ts
@@ -155,18 +155,18 @@ describe('places data', () => {
   // fetchPlace
   // ---------------------------------------------------------------------------
 
-  describe('fetchPlace', () => {
+  describe.each([true, false])('fetchPlace full: $0', (full: boolean) => {
     describe('when not logged in', () => {
       beforeEach(() => {
         (isNotLoggedIn as Mock).mockResolvedValue(true);
       });
 
       it('returns null', async () => {
-        expect(await fetchPlace(1)).toBeNull();
+        expect(await fetchPlace(1, full)).toBeNull();
       });
 
       it('does not access the database', async () => {
-        await fetchPlace(1);
+        await fetchPlace(1, full);
         expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
@@ -183,17 +183,17 @@ describe('places data', () => {
         });
 
         it('calls executeQuery', async () => {
-          await fetchPlace(1);
+          await fetchPlace(1, full);
           expect(executeQuery).toHaveBeenCalledOnce();
         });
 
         it('queries the places table', async () => {
-          await fetchPlace(1);
+          await fetchPlace(1, full);
           expect(mockFrom).toHaveBeenCalledWith('places');
         });
 
         it('returns the converted place', async () => {
-          expect(await fetchPlace(1)).toEqual(place);
+          expect(await fetchPlace(1, full)).toEqual(place);
         });
       });
 
@@ -220,7 +220,7 @@ describe('places data', () => {
         });
 
         it('returns null', async () => {
-          expect(await fetchPlace(1)).toBeNull();
+          expect(await fetchPlace(1, full)).toBeNull();
         });
       });
     });

--- a/app/adventure/places/create/__tests__/actions.spec.ts
+++ b/app/adventure/places/create/__tests__/actions.spec.ts
@@ -1,0 +1,42 @@
+import { Place } from '@/models';
+import { PLACES } from '../../__mocks__/data';
+import { createConfirmed } from '../actions';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { addPlace } from '../../data';
+import { redirect } from 'next/navigation';
+
+vi.mock('../../data');
+vi.mock('next/navigation');
+
+const place: Place = { ...PLACES.find((p) => p.id === 2)!, id: undefined };
+
+describe('places: createConfirmed', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls addPlace with the specified place', async () => {
+    await createConfirmed(place);
+    expect(addPlace).toHaveBeenCalledExactlyOnceWith(place);
+  });
+
+  describe('on success', () => {
+    beforeEach(() => {
+      (addPlace as any).mockResolvedValue({ ...place, id: 73 });
+    });
+
+    it('redirects to the places page', async () => {
+      await createConfirmed(place);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/places');
+    });
+  });
+
+  describe('on failure', () => {
+    beforeEach(() => {
+      (addPlace as any).mockResolvedValue(null);
+    });
+
+    it('redirects to the error page', async () => {
+      await createConfirmed(place);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
+    });
+  });
+});

--- a/app/adventure/places/create/__tests__/actions.spec.ts
+++ b/app/adventure/places/create/__tests__/actions.spec.ts
@@ -1,11 +1,11 @@
 import { Place } from '@/models';
-import { PLACES } from '../../__mocks__/data';
+import { PLACES } from '@/app/adventure/places/__mocks__/data';
 import { createConfirmed } from '../actions';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { addPlace } from '../../data';
+import { addPlace } from '@/app/adventure/places/data';
 import { redirect } from 'next/navigation';
 
-vi.mock('../../data');
+vi.mock('@/app/adventure/places/data');
 vi.mock('next/navigation');
 
 const place: Place = { ...PLACES.find((p) => p.id === 2)!, id: undefined };


### PR DESCRIPTION
Provide comprehensive unit tests for the places data layer functions and associated Next.js server actions. These tests validate data retrieval, manipulation, authentication checks, and redirection logic for places and place notes.

Relates to #21