### PR TITLE
Add tests for todos data layer and actions

### DIFF
--- a/.changeset/stale-fans-warn.md
+++ b/.changeset/stale-fans-warn.md
@@ -1,0 +1,5 @@
+---
+'recreation-planner': patch
+---
+
+Add tests for the todos data layer and actions.

--- a/app/adventure/todos/[id]/delete/__tests__/actions.spec.ts
+++ b/app/adventure/todos/[id]/delete/__tests__/actions.spec.ts
@@ -1,0 +1,57 @@
+import { TODO_COLLECTIONS } from '@/app/adventure/todos/__mocks__/data';
+import { deleteTodoCollection } from '@/app/adventure/todos/data';
+import { TodoCollection } from '@/models';
+import { redirect } from 'next/navigation';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { deleteAborted, deleteConfirmed } from '../actions';
+
+vi.mock('@/app/adventure/todos/data');
+vi.mock('next/navigation');
+
+const todoCollection: TodoCollection = TODO_COLLECTIONS.find((c) => c.id === 1)!;
+
+describe('todos: delete actions', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe.each([
+    {
+      page: 'Home',
+      path: '/adventure',
+    },
+    {
+      page: 'Default',
+      path: '/adventure/todos',
+    },
+  ])('deleteConfirmed for $page', ({ page, path }) => {
+    it('calls deleteTodoCollection', async () => {
+      await deleteConfirmed(todoCollection, page).catch(() => {});
+      expect(deleteTodoCollection).toHaveBeenCalledExactlyOnceWith(todoCollection);
+    });
+
+    it('redirects to /adventure/todos', async () => {
+      await deleteConfirmed(todoCollection, page).catch(() => {});
+      expect(redirect).toHaveBeenCalledExactlyOnceWith(path);
+    });
+  });
+
+  describe.each([
+    {
+      page: 'Home',
+      path: '/adventure',
+    },
+    {
+      page: 'Default',
+      path: '/adventure/todos',
+    },
+  ])('deleteAborted for $page', ({ page, path }) => {
+    it('does not call deleteTodoCollection', async () => {
+      await deleteAborted(page).catch(() => {});
+      expect(deleteTodoCollection).not.toHaveBeenCalled();
+    });
+
+    it('redirects to /adventure/todos', async () => {
+      await deleteAborted(page).catch(() => {});
+      expect(redirect).toHaveBeenCalledExactlyOnceWith(path);
+    });
+  });
+});

--- a/app/adventure/todos/[id]/update/__tests__/actions.spec.ts
+++ b/app/adventure/todos/[id]/update/__tests__/actions.spec.ts
@@ -29,7 +29,7 @@ describe.each([
 
   describe('when the update succeeds', () => {
     beforeEach(() => {
-      (updateTodoCollection as any).mockResolvedValue(true);
+      (updateTodoCollection as any).mockResolvedValue(todoCollection);
     });
 
     it('redirects to the todos list page', async () => {

--- a/app/adventure/todos/[id]/update/__tests__/actions.spec.ts
+++ b/app/adventure/todos/[id]/update/__tests__/actions.spec.ts
@@ -1,0 +1,51 @@
+import { TodoCollection } from '@/models';
+import { redirect } from 'next/navigation';
+import { describe, beforeEach, vi, it, expect } from 'vitest';
+import { TODO_COLLECTIONS } from '@/app/adventure/todos/__mocks__/data';
+import { updateConfirmed } from '../actions';
+import { updateTodoCollection } from '@/app/adventure/todos/data';
+
+vi.mock('@/app/adventure/todos/data');
+vi.mock('next/navigation');
+
+const todoCollection: TodoCollection = TODO_COLLECTIONS.find((c) => c.id === 1)!;
+
+describe.each([
+  {
+    page: 'Home',
+    path: '/adventure',
+  },
+  {
+    page: 'Default',
+    path: '/adventure/todos',
+  },
+])('todos: updateConfirmed for $page', ({ page, path }) => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls updateTodoCollection with the specified collection', async () => {
+    await updateConfirmed(todoCollection, page);
+    expect(updateTodoCollection).toHaveBeenCalledExactlyOnceWith(todoCollection);
+  });
+
+  describe('when the update succeeds', () => {
+    beforeEach(() => {
+      (updateTodoCollection as any).mockResolvedValue(true);
+    });
+
+    it('redirects to the todos list page', async () => {
+      await updateConfirmed(todoCollection, page);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith(path);
+    });
+  });
+
+  describe('when the update fails', () => {
+    beforeEach(() => {
+      (updateTodoCollection as any).mockResolvedValue(null);
+    });
+
+    it('redirects to /error', async () => {
+      await updateConfirmed(todoCollection, page);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
+    });
+  });
+});

--- a/app/adventure/todos/__tests__/data.spec.ts
+++ b/app/adventure/todos/__tests__/data.spec.ts
@@ -1,0 +1,612 @@
+import { executeQuery } from '@/utils/data';
+import { isNotLoggedIn } from '@/utils/supabase/auth';
+import { createClient } from '@/utils/supabase/server';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import {
+  addTodoCollection,
+  addTodoItem,
+  canDeleteTodoCollection,
+  canDeleteTodoItem,
+  deleteTodoCollection,
+  deleteTodoItem,
+  fetchDueTodoCollections,
+  fetchTodoCollection,
+  fetchTodoCollections,
+  updateTodoCollection,
+  updateTodoItem,
+} from '../data';
+
+vi.mock('@/utils/supabase/auth');
+vi.mock('@/utils/supabase/server');
+vi.mock('@/utils/data', () => ({ executeQuery: vi.fn() }));
+
+// --- Test data ---
+
+const todoItemDTO = {
+  id: 5,
+  name: 'Tent',
+  is_complete: false,
+  todo_collection_rid: 1,
+};
+
+const todoItem = {
+  id: 5,
+  name: 'Tent',
+  isComplete: false,
+  todoCollectionRid: 1,
+};
+
+const todoCollectionDTO = {
+  id: 1,
+  name: 'Pack for camping',
+  description: 'Things to bring',
+  due_date: '2025-07-01',
+  is_complete: false,
+  event_rid: null,
+  equipment_rid: null,
+  todo_items: [],
+};
+
+const todoCollection = {
+  id: 1,
+  name: 'Pack for camping',
+  description: 'Things to bring',
+  dueDate: '2025-07-01',
+  isComplete: false,
+  eventRid: null,
+  event: undefined,
+  equipmentRid: null,
+  equipment: undefined,
+  todoItems: [],
+};
+
+// --- Helpers ---
+
+const buildChainableMock = () => {
+  const chain: Record<string, Mock> = {};
+  ['select', 'insert', 'update', 'delete', 'eq', 'single', 'order', 'lt'].forEach((method) => {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  });
+  return chain;
+};
+
+// --- Tests ---
+
+describe('todos data', () => {
+  let mockFrom: Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const chain = buildChainableMock();
+    mockFrom = vi.fn().mockReturnValue(chain);
+    vi.mocked(createClient).mockReturnValue({ from: mockFrom } as any);
+  });
+
+  // ---------------------------------------------------------------------------
+  // fetchTodoCollections
+  // ---------------------------------------------------------------------------
+
+  describe('fetchTodoCollections', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns an empty array', async () => {
+        expect(await fetchTodoCollections()).toEqual([]);
+      });
+
+      it('does not access the database', async () => {
+        await fetchTodoCollections();
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue([todoCollectionDTO]);
+        });
+
+        it('calls executeQuery', async () => {
+          await fetchTodoCollections();
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('queries the todo_collections table', async () => {
+          await fetchTodoCollections();
+          expect(mockFrom).toHaveBeenCalledWith('todo_collections');
+        });
+
+        it('returns the converted todo collections', async () => {
+          expect(await fetchTodoCollections()).toEqual([todoCollection]);
+        });
+      });
+
+      describe('when no data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns an empty array', async () => {
+          expect(await fetchTodoCollections()).toEqual([]);
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // fetchTodoCollection
+  // ---------------------------------------------------------------------------
+
+  describe('fetchTodoCollection', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns null', async () => {
+        expect(await fetchTodoCollection(1)).toBeNull();
+      });
+
+      it('does not access the database', async () => {
+        await fetchTodoCollection(1);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(todoCollectionDTO);
+        });
+
+        it('calls executeQuery', async () => {
+          await fetchTodoCollection(1);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('queries the todo_collections table', async () => {
+          await fetchTodoCollection(1);
+          expect(mockFrom).toHaveBeenCalledWith('todo_collections');
+        });
+
+        it('returns the converted todo collection', async () => {
+          expect(await fetchTodoCollection(1)).toEqual(todoCollection);
+        });
+      });
+
+      describe('when no data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns null', async () => {
+          expect(await fetchTodoCollection(1)).toBeNull();
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // fetchDueTodoCollections
+  // ---------------------------------------------------------------------------
+
+  describe('fetchDueTodoCollections', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns an empty array', async () => {
+        expect(await fetchDueTodoCollections('2025-07-01')).toEqual([]);
+      });
+
+      it('does not access the database', async () => {
+        await fetchDueTodoCollections('2025-07-01');
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue([todoCollectionDTO]);
+        });
+
+        it('calls executeQuery', async () => {
+          await fetchDueTodoCollections('2025-07-01');
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('queries the todo_collections table', async () => {
+          await fetchDueTodoCollections('2025-07-01');
+          expect(mockFrom).toHaveBeenCalledWith('todo_collections');
+        });
+
+        it('returns the converted todo collections', async () => {
+          expect(await fetchDueTodoCollections('2025-07-01')).toEqual([todoCollection]);
+        });
+      });
+
+      describe('when no data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns an empty array', async () => {
+          expect(await fetchDueTodoCollections('2025-07-01')).toEqual([]);
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // addTodoCollection
+  // ---------------------------------------------------------------------------
+
+  describe('addTodoCollection', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns null', async () => {
+        expect(await addTodoCollection(todoCollection)).toBeNull();
+      });
+
+      it('does not access the database', async () => {
+        await addTodoCollection(todoCollection);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when the insert succeeds', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(todoCollectionDTO);
+        });
+
+        it('calls executeQuery', async () => {
+          await addTodoCollection(todoCollection);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('inserts into the todo_collections table', async () => {
+          await addTodoCollection(todoCollection);
+          expect(mockFrom).toHaveBeenCalledWith('todo_collections');
+        });
+
+        it('returns the converted todo collection', async () => {
+          expect(await addTodoCollection(todoCollection)).toEqual(todoCollection);
+        });
+      });
+
+      describe('when the insert fails', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns null', async () => {
+          expect(await addTodoCollection(todoCollection)).toBeNull();
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // canDeleteTodoCollection
+  // ---------------------------------------------------------------------------
+
+  describe('canDeleteTodoCollection', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns false', async () => {
+        expect(await canDeleteTodoCollection(todoCollection)).toBe(false);
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      it('returns true', async () => {
+        expect(await canDeleteTodoCollection(todoCollection)).toBe(true);
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // deleteTodoCollection
+  // ---------------------------------------------------------------------------
+
+  describe('deleteTodoCollection', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('does not access the database', async () => {
+        await deleteTodoCollection(todoCollection);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+        (executeQuery as Mock).mockResolvedValue(null);
+      });
+
+      it('calls executeQuery', async () => {
+        await deleteTodoCollection(todoCollection);
+        expect(executeQuery).toHaveBeenCalledOnce();
+      });
+
+      it('deletes from the todo_collections table', async () => {
+        await deleteTodoCollection(todoCollection);
+        expect(mockFrom).toHaveBeenCalledWith('todo_collections');
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // updateTodoCollection
+  // ---------------------------------------------------------------------------
+
+  describe('updateTodoCollection', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns null', async () => {
+        expect(await updateTodoCollection(todoCollection)).toBeNull();
+      });
+
+      it('does not access the database', async () => {
+        await updateTodoCollection(todoCollection);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when the update succeeds', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(todoCollectionDTO);
+        });
+
+        it('calls executeQuery', async () => {
+          await updateTodoCollection(todoCollection);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('updates the todo_collections table', async () => {
+          await updateTodoCollection(todoCollection);
+          expect(mockFrom).toHaveBeenCalledWith('todo_collections');
+        });
+
+        it('returns the converted todo collection', async () => {
+          expect(await updateTodoCollection(todoCollection)).toEqual(todoCollection);
+        });
+      });
+
+      describe('when the update fails', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns null', async () => {
+          expect(await updateTodoCollection(todoCollection)).toBeNull();
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // addTodoItem
+  // ---------------------------------------------------------------------------
+
+  describe('addTodoItem', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns null', async () => {
+        expect(await addTodoItem(todoItem)).toBeNull();
+      });
+
+      it('does not access the database', async () => {
+        await addTodoItem(todoItem);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when the insert succeeds', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(todoItemDTO);
+        });
+
+        it('calls executeQuery', async () => {
+          await addTodoItem(todoItem);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('inserts into the todo_items table', async () => {
+          await addTodoItem(todoItem);
+          expect(mockFrom).toHaveBeenCalledWith('todo_items');
+        });
+
+        it('returns the converted todo item', async () => {
+          expect(await addTodoItem(todoItem)).toEqual(todoItem);
+        });
+      });
+
+      describe('when the insert fails', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns null', async () => {
+          expect(await addTodoItem(todoItem)).toBeNull();
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // canDeleteTodoItem
+  // ---------------------------------------------------------------------------
+
+  describe('canDeleteTodoItem', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns false', async () => {
+        expect(await canDeleteTodoItem(todoItem)).toBe(false);
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      it('returns true', async () => {
+        expect(await canDeleteTodoItem(todoItem)).toBe(true);
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // deleteTodoItem
+  // ---------------------------------------------------------------------------
+
+  describe('deleteTodoItem', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('does not access the database', async () => {
+        await deleteTodoItem(todoItem);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+        (executeQuery as Mock).mockResolvedValue(null);
+      });
+
+      it('calls executeQuery', async () => {
+        await deleteTodoItem(todoItem);
+        expect(executeQuery).toHaveBeenCalledOnce();
+      });
+
+      it('deletes from the todo_items table', async () => {
+        await deleteTodoItem(todoItem);
+        expect(mockFrom).toHaveBeenCalledWith('todo_items');
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // updateTodoItem
+  // ---------------------------------------------------------------------------
+
+  describe('updateTodoItem', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns null', async () => {
+        expect(await updateTodoItem(todoItem)).toBeNull();
+      });
+
+      it('does not access the database', async () => {
+        await updateTodoItem(todoItem);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when the update succeeds', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(todoItemDTO);
+        });
+
+        it('calls executeQuery', async () => {
+          await updateTodoItem(todoItem);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('updates the todo_items table', async () => {
+          await updateTodoItem(todoItem);
+          expect(mockFrom).toHaveBeenCalledWith('todo_items');
+        });
+
+        it('returns the converted todo item', async () => {
+          expect(await updateTodoItem(todoItem)).toEqual(todoItem);
+        });
+      });
+
+      describe('when the update fails', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns null', async () => {
+          expect(await updateTodoItem(todoItem)).toBeNull();
+        });
+      });
+    });
+  });
+});

--- a/app/adventure/todos/__tests__/data.spec.ts
+++ b/app/adventure/todos/__tests__/data.spec.ts
@@ -60,6 +60,16 @@ const todoCollection = {
   todoItems: [],
 };
 
+const todoCollectionDTOWithItems = {
+  ...todoCollectionDTO,
+  todo_items: [todoItemDTO],
+};
+
+const todoCollectionWithItems = {
+  ...todoCollection,
+  todoItems: [todoItem],
+};
+
 // --- Helpers ---
 
 const buildChainableMock = () => {
@@ -126,6 +136,11 @@ describe('todos data', () => {
         it('returns the converted todo collections', async () => {
           expect(await fetchTodoCollections()).toEqual([todoCollection]);
         });
+
+        it('converts nested todo items', async () => {
+          (executeQuery as Mock).mockResolvedValueOnce([todoCollectionDTOWithItems]);
+          expect(await fetchTodoCollections()).toEqual([todoCollectionWithItems]);
+        });
       });
 
       describe('when no data is returned', () => {
@@ -183,6 +198,11 @@ describe('todos data', () => {
 
         it('returns the converted todo collection', async () => {
           expect(await fetchTodoCollection(1)).toEqual(todoCollection);
+        });
+
+        it('converts nested todo items', async () => {
+          (executeQuery as Mock).mockResolvedValueOnce(todoCollectionDTOWithItems);
+          expect(await fetchTodoCollection(1)).toEqual(todoCollectionWithItems);
         });
       });
 

--- a/app/adventure/todos/create/__tests__/actions.spec.ts
+++ b/app/adventure/todos/create/__tests__/actions.spec.ts
@@ -1,0 +1,42 @@
+import { TodoCollection } from '@/models';
+import { TODO_COLLECTIONS } from '@/app/adventure/todos/__mocks__/data';
+import { redirect } from 'next/navigation';
+import { describe, beforeEach, vi, it, expect } from 'vitest';
+import { createConfirmed } from '../actions';
+import { addTodoCollection } from '@/app/adventure/todos/data';
+
+vi.mock('@/app/adventure/todos/data');
+vi.mock('next/navigation');
+
+const todoCollection: TodoCollection = { ...TODO_COLLECTIONS.find((c) => c.id === 1)!, id: undefined };
+
+describe('todo collection: createConfirmed', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls addTodoCollection with the specified collection', async () => {
+    await createConfirmed(todoCollection);
+    expect(addTodoCollection).toHaveBeenCalledExactlyOnceWith(todoCollection);
+  });
+
+  describe('when addTodoCollection succeeds', () => {
+    beforeEach(() => {
+      (addTodoCollection as any).mockResolvedValue({ ...todoCollection, id: 73 });
+    });
+
+    it('redirects to the todo collections list page', async () => {
+      await createConfirmed(todoCollection);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/todos');
+    });
+  });
+
+  describe('when addTodoCollection fails', () => {
+    beforeEach(() => {
+      (addTodoCollection as any).mockResolvedValue(null);
+    });
+
+    it('redirects to /error', async () => {
+      await createConfirmed(todoCollection);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
+    });
+  });
+});


### PR DESCRIPTION
Adds comprehensive unit tests for the 'todos' feature, covering all data layer operations and related Next.js server actions to ensure reliability and correct behavior across various scenarios, including authentication and redirection.
Relates to #23