### PR TITLE
Add unit tests for data layers and actions

### DIFF
--- a/.changeset/brave-bushes-check.md
+++ b/.changeset/brave-bushes-check.md
@@ -1,0 +1,5 @@
+---
+'recreation-planner': patch
+---
+
+add tests for the itinerary data layer and actions

--- a/.changeset/cyan-lizards-win.md
+++ b/.changeset/cyan-lizards-win.md
@@ -1,0 +1,5 @@
+---
+'recreation-planner': patch
+---
+
+add unit tests for the equipment data layer and actions

--- a/.changeset/honest-coats-punch.md
+++ b/.changeset/honest-coats-punch.md
@@ -1,0 +1,5 @@
+---
+'recreation-planner': patch
+---
+
+add tests for the places data layer and actions

--- a/.changeset/smart-items-play.md
+++ b/.changeset/smart-items-play.md
@@ -1,0 +1,5 @@
+---
+'recreation-planner': patch
+---
+
+Add tests for the notes data layer and actions.

--- a/.changeset/stale-fans-warn.md
+++ b/.changeset/stale-fans-warn.md
@@ -1,0 +1,5 @@
+---
+'recreation-planner': patch
+---
+
+Add tests for the todos data layer and actions.

--- a/.changeset/tender-bikes-wonder.md
+++ b/.changeset/tender-bikes-wonder.md
@@ -1,0 +1,5 @@
+---
+'recreation-planner': patch
+---
+
+Add tests for the events data layer and actions.

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+max_line_length = 120
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/app/adventure/equipment/[id]/delete/__tests__/action.spec.ts
+++ b/app/adventure/equipment/[id]/delete/__tests__/action.spec.ts
@@ -1,0 +1,57 @@
+import { Equipment } from '@/models';
+import { redirect } from 'next/navigation';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { deleteEquipment } from '../../../data';
+import { deleteAborted, deleteConfirmed } from '../actions';
+
+vi.mock('../../../data');
+vi.mock('next/navigation');
+
+const equipment: Equipment = {
+  id: 42,
+  name: 'Test Kayak',
+  description: 'A kayak for testing',
+  purchaseDate: null,
+  cost: null,
+  manufacturer: null,
+  model: null,
+  identification: null,
+  length: null,
+  weight: null,
+  capacity: null,
+  licensePlateNumber: null,
+  insuranceCarrier: null,
+  insurancePolicyNumber: null,
+  insuranceContactName: null,
+  insuranceContactPhoneNumber: null,
+  insuranceContactEmail: null,
+  equipmentType: { id: 1, name: 'Kayak', description: 'A small boat' },
+};
+
+describe('equipment: delete actions', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe('deleteAborted', () => {
+    it('does not call deleteEquipment', async () => {
+      await deleteAborted().catch(() => {});
+      expect(deleteEquipment).not.toHaveBeenCalled();
+    });
+
+    it('redirects to /adventure/equipment', async () => {
+      await deleteAborted().catch(() => {});
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/equipment');
+    });
+  });
+
+  describe('deleteConfirmed', () => {
+    it('calls deleteEquipment with the passed equipment', async () => {
+      await deleteConfirmed(equipment).catch(() => {});
+      expect(deleteEquipment).toHaveBeenCalledExactlyOnceWith(equipment);
+    });
+
+    it('redirects to /adventure/equipment', async () => {
+      await deleteConfirmed(equipment).catch(() => {});
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/equipment');
+    });
+  });
+});

--- a/app/adventure/equipment/[id]/maintenance/[maintenanceItemId]/update/__tests__/actions.spec.ts
+++ b/app/adventure/equipment/[id]/maintenance/[maintenanceItemId]/update/__tests__/actions.spec.ts
@@ -1,0 +1,45 @@
+import { MAINTENANCE_ITEMS } from '@/app/adventure/equipment/__mocks__/data';
+import { updateMaintenanceItem } from '@/app/adventure/equipment/data';
+import { MaintenanceItem } from '@/models';
+import { redirect } from 'next/navigation';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { updateConfirmed } from '../actions';
+
+vi.mock('@/app/adventure/equipment/data');
+vi.mock('next/navigation');
+
+const maintenanceItem: MaintenanceItem = {
+  ...MAINTENANCE_ITEMS.find((x) => x.id === 2)!,
+  equipmentRid: 314,
+};
+
+describe('equipment maintenance: updateConfirmed', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('updates the specified maintenance item', async () => {
+    await updateConfirmed(maintenanceItem);
+    expect(updateMaintenanceItem).toHaveBeenCalledExactlyOnceWith(maintenanceItem);
+  });
+
+  describe('on success', () => {
+    beforeEach(() => {
+      (updateMaintenanceItem as any).mockResolvedValue({ ...maintenanceItem });
+    });
+
+    it('redirects to the equipment details page', async () => {
+      await updateConfirmed(maintenanceItem);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/equipment/314?lastActivity=Maintenance');
+    });
+  });
+
+  describe('on failure', () => {
+    beforeEach(() => {
+      (updateMaintenanceItem as any).mockResolvedValue(null);
+    });
+
+    it('redirects to error', async () => {
+      await updateConfirmed(maintenanceItem);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
+    });
+  });
+});

--- a/app/adventure/equipment/[id]/maintenance/[maintenanceItemId]/update/__tests__/actions.spec.ts
+++ b/app/adventure/equipment/[id]/maintenance/[maintenanceItemId]/update/__tests__/actions.spec.ts
@@ -2,7 +2,7 @@ import { MAINTENANCE_ITEMS } from '@/app/adventure/equipment/__mocks__/data';
 import { updateMaintenanceItem } from '@/app/adventure/equipment/data';
 import { MaintenanceItem } from '@/models';
 import { redirect } from 'next/navigation';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import { updateConfirmed } from '../actions';
 
 vi.mock('@/app/adventure/equipment/data');
@@ -23,7 +23,7 @@ describe('equipment maintenance: updateConfirmed', () => {
 
   describe('on success', () => {
     beforeEach(() => {
-      (updateMaintenanceItem as any).mockResolvedValue({ ...maintenanceItem });
+      (updateMaintenanceItem as Mock).mockResolvedValue({ ...maintenanceItem });
     });
 
     it('redirects to the equipment details page', async () => {
@@ -34,7 +34,7 @@ describe('equipment maintenance: updateConfirmed', () => {
 
   describe('on failure', () => {
     beforeEach(() => {
-      (updateMaintenanceItem as any).mockResolvedValue(null);
+      (updateMaintenanceItem as Mock).mockResolvedValue(null);
     });
 
     it('redirects to error', async () => {

--- a/app/adventure/equipment/[id]/maintenance/create/__tests__/actions.spec.ts
+++ b/app/adventure/equipment/[id]/maintenance/create/__tests__/actions.spec.ts
@@ -1,9 +1,9 @@
 import { MAINTENANCE_ITEMS } from '@/app/adventure/equipment/__mocks__/data';
-import { createConfirmed } from '../actions';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { addMaintenanceItem } from '@/app/adventure/equipment/data';
-import { redirect } from 'next/navigation';
 import { MaintenanceItem } from '@/models';
+import { redirect } from 'next/navigation';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { createConfirmed } from '../actions';
 
 vi.mock('@/app/adventure/equipment/data');
 vi.mock('next/navigation');
@@ -24,7 +24,7 @@ describe('equipment maintenance: createConfirmed', () => {
 
   describe('on success', () => {
     beforeEach(() => {
-      (addMaintenanceItem as any).mockResolvedValue({ ...maintenanceItem, id: 73 });
+      (addMaintenanceItem as Mock).mockResolvedValue({ ...maintenanceItem, id: 73 });
     });
 
     it('redirects to the equipment details page', async () => {
@@ -35,7 +35,7 @@ describe('equipment maintenance: createConfirmed', () => {
 
   describe('on failure', () => {
     beforeEach(() => {
-      (addMaintenanceItem as any).mockResolvedValue(null);
+      (addMaintenanceItem as Mock).mockResolvedValue(null);
     });
 
     it('redirects to error', async () => {

--- a/app/adventure/equipment/[id]/maintenance/create/__tests__/actions.spec.ts
+++ b/app/adventure/equipment/[id]/maintenance/create/__tests__/actions.spec.ts
@@ -1,0 +1,46 @@
+import { MAINTENANCE_ITEMS } from '@/app/adventure/equipment/__mocks__/data';
+import { createConfirmed } from '../actions';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { addMaintenanceItem } from '@/app/adventure/equipment/data';
+import { redirect } from 'next/navigation';
+import { MaintenanceItem } from '@/models';
+
+vi.mock('@/app/adventure/equipment/data');
+vi.mock('next/navigation');
+
+const maintenanceItem: MaintenanceItem = {
+  ...MAINTENANCE_ITEMS.find((x) => x.id === 2)!,
+  equipmentRid: 314,
+  id: undefined,
+};
+
+describe('equipment maintenance: createConfirmed', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('adds the specified maintenance item', async () => {
+    await createConfirmed(maintenanceItem);
+    expect(addMaintenanceItem).toHaveBeenCalledExactlyOnceWith(maintenanceItem);
+  });
+
+  describe('on success', () => {
+    beforeEach(() => {
+      (addMaintenanceItem as any).mockResolvedValue({ ...maintenanceItem, id: 73 });
+    });
+
+    it('redirects to the equipment details page', async () => {
+      await createConfirmed(maintenanceItem);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/equipment/314?lastActivity=Maintenance');
+    });
+  });
+
+  describe('on failure', () => {
+    beforeEach(() => {
+      (addMaintenanceItem as any).mockResolvedValue(null);
+    });
+
+    it('redirects to error', async () => {
+      await createConfirmed(maintenanceItem);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
+    });
+  });
+});

--- a/app/adventure/equipment/[id]/notes/[noteId]/delete/__tests__/actions.spec.ts
+++ b/app/adventure/equipment/[id]/notes/[noteId]/delete/__tests__/actions.spec.ts
@@ -1,0 +1,45 @@
+import { Note } from '@/models';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { deleteAborted, deleteConfirmed } from '../actions';
+import { deleteNote } from '@/app/adventure/notes/data';
+import { redirect } from 'next/navigation';
+
+vi.mock('@/app/adventure/notes/data');
+vi.mock('next/navigation');
+
+const note: Note = {
+  id: 73,
+  name: 'Test Note',
+  description: 'A note for testing',
+  equipmentRid: 42,
+  placeRid: null,
+  eventRid: null,
+};
+
+describe('equipment notes: delete actions', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe('deleteConfirmed', () => {
+    it('calls deleteNote', async () => {
+      await deleteConfirmed(19, note);
+      expect(deleteNote).toHaveBeenCalledExactlyOnceWith(note);
+    });
+
+    it('redirects to the equipment details page', async () => {
+      await deleteConfirmed(19, note);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/equipment/19?lastActivity=Notes');
+    });
+  });
+
+  describe('deleteAborted', () => {
+    it('does not call deleteNote', async () => {
+      await deleteAborted(19);
+      expect(deleteNote).not.toHaveBeenCalled();
+    });
+
+    it('redirects to the equipment details page', async () => {
+      await deleteAborted(19);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/equipment/19?lastActivity=Notes');
+    });
+  });
+});

--- a/app/adventure/equipment/[id]/notes/[noteId]/update/__tests__/actions.spec.ts
+++ b/app/adventure/equipment/[id]/notes/[noteId]/update/__tests__/actions.spec.ts
@@ -1,0 +1,48 @@
+import { updateNote } from '@/app/adventure/notes/data';
+import { Note } from '@/models';
+import { redirect } from 'next/navigation';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { updateConfirmed } from '../actions';
+
+vi.mock('@/app/adventure/notes/data');
+vi.mock('next/navigation');
+
+const note: Note = {
+  id: 73,
+  name: 'Test Note',
+  description: 'A note for testing',
+  equipmentRid: 42,
+  placeRid: null,
+  eventRid: null,
+};
+
+describe('equipment notes: updateConfirmed', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls updateNote with the specified note', async () => {
+    await updateConfirmed(note);
+    expect(updateNote).toHaveBeenCalledExactlyOnceWith(note);
+  });
+
+  describe('when the update succeeds', () => {
+    beforeEach(() => {
+      (updateNote as any).mockResolvedValue(note);
+    });
+
+    it('redirects to the equipment details page', async () => {
+      await updateConfirmed(note);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/equipment/42?lastActivity=Notes');
+    });
+  });
+
+  describe('when the update fails', () => {
+    beforeEach(() => {
+      (updateNote as any).mockResolvedValue(null);
+    });
+
+    it('redirects to /error', async () => {
+      await updateConfirmed(note);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
+    });
+  });
+});

--- a/app/adventure/equipment/[id]/notes/[noteId]/update/__tests__/actions.spec.ts
+++ b/app/adventure/equipment/[id]/notes/[noteId]/update/__tests__/actions.spec.ts
@@ -1,7 +1,7 @@
 import { updateNote } from '@/app/adventure/notes/data';
 import { Note } from '@/models';
 import { redirect } from 'next/navigation';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import { updateConfirmed } from '../actions';
 
 vi.mock('@/app/adventure/notes/data');
@@ -26,7 +26,7 @@ describe('equipment notes: updateConfirmed', () => {
 
   describe('when the update succeeds', () => {
     beforeEach(() => {
-      (updateNote as any).mockResolvedValue(note);
+      (updateNote as Mock).mockResolvedValue(note);
     });
 
     it('redirects to the equipment details page', async () => {
@@ -37,7 +37,7 @@ describe('equipment notes: updateConfirmed', () => {
 
   describe('when the update fails', () => {
     beforeEach(() => {
-      (updateNote as any).mockResolvedValue(null);
+      (updateNote as Mock).mockResolvedValue(null);
     });
 
     it('redirects to /error', async () => {

--- a/app/adventure/equipment/[id]/notes/create/__tests__/actions.spec.ts
+++ b/app/adventure/equipment/[id]/notes/create/__tests__/actions.spec.ts
@@ -1,8 +1,8 @@
-import { Note } from '@/models';
-import { createConfirmed } from '../actions';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { addNote } from '@/app/adventure/notes/data';
+import { Note } from '@/models';
 import { redirect } from 'next/navigation';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { createConfirmed } from '../actions';
 
 vi.mock('@/app/adventure/notes/data');
 vi.mock('next/navigation');
@@ -25,7 +25,7 @@ describe('equipment note: create', () => {
 
   describe('when addNote succeeds', () => {
     beforeEach(() => {
-      (addNote as any).mockResolvedValue({ ...note, id: 73 });
+      (addNote as Mock).mockResolvedValue({ ...note, id: 73 });
     });
 
     it('redirects to the equipment details page', async () => {
@@ -36,7 +36,7 @@ describe('equipment note: create', () => {
 
   describe('when addNote fails', () => {
     beforeEach(() => {
-      (addNote as any).mockResolvedValue(null);
+      (addNote as Mock).mockResolvedValue(null);
     });
 
     it('redirects to /error', async () => {

--- a/app/adventure/equipment/[id]/notes/create/__tests__/actions.spec.ts
+++ b/app/adventure/equipment/[id]/notes/create/__tests__/actions.spec.ts
@@ -1,0 +1,47 @@
+import { Note } from '@/models';
+import { createConfirmed } from '../actions';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { addNote } from '@/app/adventure/notes/data';
+import { redirect } from 'next/navigation';
+
+vi.mock('@/app/adventure/notes/data');
+vi.mock('next/navigation');
+
+const note: Note = {
+  name: 'Test Note',
+  description: 'A note for testing',
+  equipmentRid: 42,
+  placeRid: null,
+  eventRid: null,
+};
+
+describe('equipment note: create', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls addNote with the specified note', async () => {
+    await createConfirmed(note);
+    expect(addNote).toHaveBeenCalledExactlyOnceWith(note);
+  });
+
+  describe('when addNote succeeds', () => {
+    beforeEach(() => {
+      (addNote as any).mockResolvedValue({ ...note, id: 73 });
+    });
+
+    it('redirects to the equipment details page', async () => {
+      await createConfirmed(note);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/equipment/42?lastActivity=Notes');
+    });
+  });
+
+  describe('when addNote fails', () => {
+    beforeEach(() => {
+      (addNote as any).mockResolvedValue(null);
+    });
+
+    it('redirects to /error', async () => {
+      await createConfirmed(note);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
+    });
+  });
+});

--- a/app/adventure/equipment/[id]/todos/[collectionId]/delete/__tests__/actions.spec.ts
+++ b/app/adventure/equipment/[id]/todos/[collectionId]/delete/__tests__/actions.spec.ts
@@ -1,0 +1,39 @@
+import { TODO_COLLECTIONS } from '@/app/adventure/todos/__mocks__/data';
+import { deleteTodoCollection } from '@/app/adventure/todos/data';
+import { TodoCollection } from '@/models';
+import { redirect } from 'next/navigation';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { deleteAborted, deleteConfirmed } from '../actions';
+
+vi.mock('@/app/adventure/todos/data');
+vi.mock('next/navigation');
+
+const collection: TodoCollection = { ...TODO_COLLECTIONS.find((x) => x.id === 1)!, equipmentRid: 42 };
+
+describe('equipment TODOs: delete actions', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe('deleteConfirmed', () => {
+    it('calls deleteTodoCollection', async () => {
+      await deleteConfirmed(19, collection);
+      expect(deleteTodoCollection).toHaveBeenCalledExactlyOnceWith(collection);
+    });
+
+    it('redirects to the equipment details page', async () => {
+      await deleteConfirmed(19, collection);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/equipment/19?lastActivity=Todos');
+    });
+  });
+
+  describe('deleteAborted', () => {
+    it('does not call deleteTodoCollection', async () => {
+      await deleteAborted(19);
+      expect(deleteTodoCollection).not.toHaveBeenCalled();
+    });
+
+    it('redirects to the equipment details page', async () => {
+      await deleteAborted(19);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/equipment/19?lastActivity=Todos');
+    });
+  });
+});

--- a/app/adventure/equipment/[id]/todos/[collectionId]/update/__tests__/actions.spec.ts
+++ b/app/adventure/equipment/[id]/todos/[collectionId]/update/__tests__/actions.spec.ts
@@ -2,7 +2,7 @@ import { TODO_COLLECTIONS } from '@/app/adventure/todos/__mocks__/data';
 import { updateTodoCollection } from '@/app/adventure/todos/data';
 import { TodoCollection } from '@/models';
 import { redirect } from 'next/navigation';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import { updateConfirmed } from '../actions';
 
 vi.mock('@/app/adventure/todos/data');
@@ -20,7 +20,7 @@ describe('equipment TODOs: updateConfirmed', () => {
 
   describe('on success', () => {
     beforeEach(() => {
-      (updateTodoCollection as any).mockResolvedValue(collection);
+      (updateTodoCollection as Mock).mockResolvedValue(collection);
     });
 
     it('redirects to the equipment details page', async () => {
@@ -31,7 +31,7 @@ describe('equipment TODOs: updateConfirmed', () => {
 
   describe('on failure', () => {
     beforeEach(() => {
-      (updateTodoCollection as any).mockResolvedValue(null);
+      (updateTodoCollection as Mock).mockResolvedValue(null);
     });
 
     it('redirects to error', async () => {

--- a/app/adventure/equipment/[id]/todos/[collectionId]/update/__tests__/actions.spec.ts
+++ b/app/adventure/equipment/[id]/todos/[collectionId]/update/__tests__/actions.spec.ts
@@ -1,0 +1,42 @@
+import { TODO_COLLECTIONS } from '@/app/adventure/todos/__mocks__/data';
+import { updateTodoCollection } from '@/app/adventure/todos/data';
+import { TodoCollection } from '@/models';
+import { redirect } from 'next/navigation';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { updateConfirmed } from '../actions';
+
+vi.mock('@/app/adventure/todos/data');
+vi.mock('next/navigation');
+
+const collection: TodoCollection = { ...TODO_COLLECTIONS.find((x) => x.id === 1)!, equipmentRid: 42 };
+
+describe('equipment TODOs: updateConfirmed', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls updateTodoCollection with the passed collection', async () => {
+    await updateConfirmed(collection);
+    expect(updateTodoCollection).toHaveBeenCalledExactlyOnceWith(collection);
+  });
+
+  describe('on success', () => {
+    beforeEach(() => {
+      (updateTodoCollection as any).mockResolvedValue(collection);
+    });
+
+    it('redirects to the equipment details page', async () => {
+      await updateConfirmed(collection);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/equipment/42?lastActivity=Todos');
+    });
+  });
+
+  describe('on failure', () => {
+    beforeEach(() => {
+      (updateTodoCollection as any).mockResolvedValue(null);
+    });
+
+    it('redirects to error', async () => {
+      await updateConfirmed(collection);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
+    });
+  });
+});

--- a/app/adventure/equipment/[id]/todos/create/__tests__/actions.spec.ts
+++ b/app/adventure/equipment/[id]/todos/create/__tests__/actions.spec.ts
@@ -2,7 +2,7 @@ import { TODO_COLLECTIONS } from '@/app/adventure/todos/__mocks__/data';
 import { addTodoCollection } from '@/app/adventure/todos/data';
 import { TodoCollection } from '@/models';
 import { redirect } from 'next/navigation';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import { createConfirmed } from '../actions';
 
 vi.mock('@/app/adventure/todos/data');
@@ -20,7 +20,7 @@ describe('equipment todos: createConfirmed', () => {
 
   describe('on success', () => {
     beforeEach(() => {
-      (addTodoCollection as any).mockResolvedValue({ ...collection, id: 73 });
+      (addTodoCollection as Mock).mockResolvedValue({ ...collection, id: 73 });
     });
 
     it('redirects to the equipment details page', async () => {
@@ -31,7 +31,7 @@ describe('equipment todos: createConfirmed', () => {
 
   describe('on failure', () => {
     beforeEach(() => {
-      (addTodoCollection as any).mockResolvedValue(null);
+      (addTodoCollection as Mock).mockResolvedValue(null);
     });
 
     it('redirects to error', async () => {

--- a/app/adventure/equipment/[id]/todos/create/__tests__/actions.spec.ts
+++ b/app/adventure/equipment/[id]/todos/create/__tests__/actions.spec.ts
@@ -1,0 +1,42 @@
+import { TODO_COLLECTIONS } from '@/app/adventure/todos/__mocks__/data';
+import { addTodoCollection } from '@/app/adventure/todos/data';
+import { TodoCollection } from '@/models';
+import { redirect } from 'next/navigation';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createConfirmed } from '../actions';
+
+vi.mock('@/app/adventure/todos/data');
+vi.mock('next/navigation');
+
+const collection: TodoCollection = { ...TODO_COLLECTIONS.find((x) => x.id === 2)!, id: undefined, equipmentRid: 42 };
+
+describe('equipment todos: createConfirmed', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls addTodoCollection with the specified collection', async () => {
+    await createConfirmed(collection);
+    expect(addTodoCollection).toHaveBeenCalledExactlyOnceWith(collection);
+  });
+
+  describe('on success', () => {
+    beforeEach(() => {
+      (addTodoCollection as any).mockResolvedValue({ ...collection, id: 73 });
+    });
+
+    it('redirects to the equipment details page', async () => {
+      await createConfirmed(collection);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/equipment/42?lastActivity=Todos');
+    });
+  });
+
+  describe('on failure', () => {
+    beforeEach(() => {
+      (addTodoCollection as any).mockResolvedValue(null);
+    });
+
+    it('redirects to error', async () => {
+      await createConfirmed(collection);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
+    });
+  });
+});

--- a/app/adventure/equipment/[id]/update/__tests__/actions.spec.ts
+++ b/app/adventure/equipment/[id]/update/__tests__/actions.spec.ts
@@ -1,0 +1,60 @@
+import { Equipment } from '@/models';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { updateEquipment } from '../../../data';
+import { updateConfirmed } from '../actions';
+import { redirect } from 'next/navigation';
+
+vi.mock('../../../data');
+vi.mock('next/navigation');
+
+const equipment: Equipment = {
+  id: 42,
+  name: 'Test Kayak',
+  description: 'A kayak for testing',
+  purchaseDate: null,
+  cost: null,
+  manufacturer: null,
+  model: null,
+  identification: null,
+  length: null,
+  weight: null,
+  capacity: null,
+  licensePlateNumber: null,
+  insuranceCarrier: null,
+  insurancePolicyNumber: null,
+  insuranceContactName: null,
+  insuranceContactPhoneNumber: null,
+  insuranceContactEmail: null,
+  equipmentType: { id: 1, name: 'Kayak', description: 'A small boat' },
+};
+
+describe('equipment: updateConfirmed', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls updateEquipment with the provided equipment', async () => {
+    await updateConfirmed(equipment).catch(() => {});
+    expect(updateEquipment).toHaveBeenCalledExactlyOnceWith(equipment);
+  });
+
+  describe('when updateEquipment succeeds', () => {
+    beforeEach(() => {
+      (updateEquipment as Mock).mockResolvedValue(equipment);
+    });
+
+    it('redirects to /adventure/equipment', async () => {
+      await updateConfirmed(equipment).catch(() => {});
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/equipment');
+    });
+  });
+
+  describe('when updateEquipment fails', () => {
+    beforeEach(() => {
+      (updateEquipment as Mock).mockResolvedValue(null);
+    });
+
+    it('redirects to /error', async () => {
+      await updateConfirmed(equipment).catch(() => {});
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
+    });
+  });
+});

--- a/app/adventure/equipment/__tests__/data.spec.ts
+++ b/app/adventure/equipment/__tests__/data.spec.ts
@@ -118,6 +118,7 @@ describe('equipment data', () => {
     vi.clearAllMocks();
     const chain = buildChainableMock();
     mockFrom = vi.fn().mockReturnValue(chain);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vi.mocked(createClient).mockReturnValue({ from: mockFrom } as any);
   });
 

--- a/app/adventure/equipment/__tests__/data.spec.ts
+++ b/app/adventure/equipment/__tests__/data.spec.ts
@@ -1,0 +1,827 @@
+import { executeQuery } from '@/utils/data';
+import { isNotLoggedIn } from '@/utils/supabase/auth';
+import { createClient } from '@/utils/supabase/server';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import {
+  addEquipment,
+  addMaintenanceItem,
+  canDeleteEquipment,
+  canDeleteMaintenanceItem,
+  deleteEquipment,
+  deleteMaintenanceItem,
+  fetchAllEquipment,
+  fetchEquipment,
+  fetchEquipmentTypes,
+  fetchMaintenanceItem,
+  fetchMaintenanceTypes,
+  fetchUsageUnits,
+  updateEquipment,
+  updateMaintenanceItem,
+} from '../data';
+
+vi.mock('@/utils/supabase/auth');
+vi.mock('@/utils/supabase/server');
+vi.mock('@/utils/data', () => ({ executeQuery: vi.fn() }));
+
+// --- Test data ---
+
+const equipmentTypeDTO = { id: 2, name: 'Automobile', description: 'A car or truck' };
+
+const equipmentDTO = {
+  id: 1,
+  name: 'Test Truck',
+  description: 'A test vehicle',
+  purchase_date: '2014-11-27',
+  cost: 24584.34,
+  manufacturer: 'Ford',
+  model: 'Maverick',
+  identification: 'test-vin',
+  length: null,
+  weight: null,
+  capacity: null,
+  license_plate_number: null,
+  insurance_carrier: null,
+  insurance_policy_number: null,
+  insurance_contact_name: null,
+  insurance_contact_phone_number: null,
+  insurance_contact_email: null,
+  equipment_type_rid: 2,
+  equipment_types: equipmentTypeDTO,
+};
+
+const equipment = {
+  id: 1,
+  name: 'Test Truck',
+  description: 'A test vehicle',
+  purchaseDate: '2014-11-27',
+  cost: 24584.34,
+  manufacturer: 'Ford',
+  model: 'Maverick',
+  identification: 'test-vin',
+  length: null,
+  weight: null,
+  capacity: null,
+  licensePlateNumber: null,
+  insuranceCarrier: null,
+  insurancePolicyNumber: null,
+  insuranceContactName: null,
+  insuranceContactPhoneNumber: null,
+  insuranceContactEmail: null,
+  equipmentType: { id: 2, name: 'Automobile', description: 'A car or truck' },
+};
+
+const maintenanceTypeDTO = { id: 2, name: 'Periodic Maintenance', description: 'Oil change etc.' };
+const usageUnitsDTO = { id: 1, name: 'Miles' };
+
+const maintenanceItemDTO = {
+  id: 5,
+  name: 'Oil Change',
+  description: null,
+  date: '2025-08-15',
+  cost: 123.43,
+  usage: 12834.3,
+  usage_units_rid: 1,
+  usage_units: usageUnitsDTO,
+  maintenance_type_rid: 2,
+  maintenance_types: maintenanceTypeDTO,
+  equipment_rid: 1,
+};
+
+const maintenanceItem = {
+  id: 5,
+  name: 'Oil Change',
+  description: null,
+  date: '2025-08-15',
+  cost: 123.43,
+  usage: 12834.3,
+  usageUnits: { id: 1, name: 'Miles' },
+  maintenanceType: { id: 2, name: 'Periodic Maintenance', description: 'Oil change etc.' },
+  equipmentRid: 1,
+};
+
+// --- Helpers ---
+
+const buildChainableMock = () => {
+  const chain: Record<string, Mock> = {};
+  ['select', 'insert', 'update', 'delete', 'eq', 'single', 'order'].forEach((method) => {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  });
+  return chain;
+};
+
+// --- Tests ---
+
+describe('equipment data', () => {
+  let mockFrom: Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const chain = buildChainableMock();
+    mockFrom = vi.fn().mockReturnValue(chain);
+    vi.mocked(createClient).mockReturnValue({ from: mockFrom } as any);
+  });
+
+  // ---------------------------------------------------------------------------
+  // fetchAllEquipment
+  // ---------------------------------------------------------------------------
+
+  describe('fetchAllEquipment', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns an empty array', async () => {
+        expect(await fetchAllEquipment()).toEqual([]);
+      });
+
+      it('does not access the database', async () => {
+        await fetchAllEquipment();
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue([equipmentDTO]);
+        });
+
+        it('calls executeQuery', async () => {
+          await fetchAllEquipment();
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('queries the equipment table', async () => {
+          await fetchAllEquipment();
+          expect(mockFrom).toHaveBeenCalledWith('equipment');
+        });
+
+        it('returns the converted equipment list', async () => {
+          expect(await fetchAllEquipment()).toEqual([equipment]);
+        });
+      });
+
+      describe('when no data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns an empty array', async () => {
+          expect(await fetchAllEquipment()).toEqual([]);
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // fetchEquipment
+  // ---------------------------------------------------------------------------
+
+  describe('fetchEquipment', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns null', async () => {
+        expect(await fetchEquipment(1)).toBeNull();
+      });
+
+      it('does not access the database', async () => {
+        await fetchEquipment(1);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(equipmentDTO);
+        });
+
+        it('calls executeQuery', async () => {
+          await fetchEquipment(1);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('queries the equipment table', async () => {
+          await fetchEquipment(1);
+          expect(mockFrom).toHaveBeenCalledWith('equipment');
+        });
+
+        it('returns the converted equipment', async () => {
+          expect(await fetchEquipment(1)).toEqual(equipment);
+        });
+      });
+
+      describe('when no data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns null', async () => {
+          expect(await fetchEquipment(1)).toBeNull();
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // addEquipment
+  // ---------------------------------------------------------------------------
+
+  describe('addEquipment', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns null', async () => {
+        expect(await addEquipment(equipment)).toBeNull();
+      });
+
+      it('does not access the database', async () => {
+        await addEquipment(equipment);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when the insert succeeds', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(equipmentDTO);
+        });
+
+        it('calls executeQuery', async () => {
+          await addEquipment(equipment);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('inserts into the equipment table', async () => {
+          await addEquipment(equipment);
+          expect(mockFrom).toHaveBeenCalledWith('equipment');
+        });
+
+        it('returns the converted equipment', async () => {
+          expect(await addEquipment(equipment)).toEqual(equipment);
+        });
+      });
+
+      describe('when the insert fails', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns null', async () => {
+          expect(await addEquipment(equipment)).toBeNull();
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // canDeleteEquipment
+  // ---------------------------------------------------------------------------
+
+  describe('canDeleteEquipment', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns false', async () => {
+        expect(await canDeleteEquipment(equipment)).toBe(false);
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      it('returns true', async () => {
+        expect(await canDeleteEquipment(equipment)).toBe(true);
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // deleteEquipment
+  // ---------------------------------------------------------------------------
+
+  describe('deleteEquipment', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('does not access the database', async () => {
+        await deleteEquipment(equipment);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+        (executeQuery as Mock).mockResolvedValue(null);
+      });
+
+      it('calls executeQuery', async () => {
+        await deleteEquipment(equipment);
+        expect(executeQuery).toHaveBeenCalledOnce();
+      });
+
+      it('deletes from the equipment table', async () => {
+        await deleteEquipment(equipment);
+        expect(mockFrom).toHaveBeenCalledWith('equipment');
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // updateEquipment
+  // ---------------------------------------------------------------------------
+
+  describe('updateEquipment', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns null', async () => {
+        expect(await updateEquipment(equipment)).toBeNull();
+      });
+
+      it('does not access the database', async () => {
+        await updateEquipment(equipment);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when the update succeeds', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(equipmentDTO);
+        });
+
+        it('calls executeQuery', async () => {
+          await updateEquipment(equipment);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('updates the equipment table', async () => {
+          await updateEquipment(equipment);
+          expect(mockFrom).toHaveBeenCalledWith('equipment');
+        });
+
+        it('returns the converted equipment', async () => {
+          expect(await updateEquipment(equipment)).toEqual(equipment);
+        });
+      });
+
+      describe('when the update fails', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns null', async () => {
+          expect(await updateEquipment(equipment)).toBeNull();
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // fetchEquipmentTypes
+  // ---------------------------------------------------------------------------
+
+  describe('fetchEquipmentTypes', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns an empty array', async () => {
+        expect(await fetchEquipmentTypes()).toEqual([]);
+      });
+
+      it('does not access the database', async () => {
+        await fetchEquipmentTypes();
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue([equipmentTypeDTO]);
+        });
+
+        it('calls executeQuery', async () => {
+          await fetchEquipmentTypes();
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('queries the equipment_types table', async () => {
+          await fetchEquipmentTypes();
+          expect(mockFrom).toHaveBeenCalledWith('equipment_types');
+        });
+
+        it('returns the converted equipment types', async () => {
+          expect(await fetchEquipmentTypes()).toEqual([{ id: 2, name: 'Automobile', description: 'A car or truck' }]);
+        });
+      });
+
+      describe('when no data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns an empty array', async () => {
+          expect(await fetchEquipmentTypes()).toEqual([]);
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // fetchMaintenanceItem
+  // ---------------------------------------------------------------------------
+
+  describe('fetchMaintenanceItem', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns null', async () => {
+        expect(await fetchMaintenanceItem(5)).toBeNull();
+      });
+
+      it('does not access the database', async () => {
+        await fetchMaintenanceItem(5);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(maintenanceItemDTO);
+        });
+
+        it('calls executeQuery', async () => {
+          await fetchMaintenanceItem(5);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('queries the maintenance_items table', async () => {
+          await fetchMaintenanceItem(5);
+          expect(mockFrom).toHaveBeenCalledWith('maintenance_items');
+        });
+
+        it('returns the converted maintenance item', async () => {
+          expect(await fetchMaintenanceItem(5)).toEqual(maintenanceItem);
+        });
+      });
+
+      describe('when no data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns null', async () => {
+          expect(await fetchMaintenanceItem(5)).toBeNull();
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // addMaintenanceItem
+  // ---------------------------------------------------------------------------
+
+  describe('addMaintenanceItem', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns null', async () => {
+        expect(await addMaintenanceItem(maintenanceItem)).toBeNull();
+      });
+
+      it('does not access the database', async () => {
+        await addMaintenanceItem(maintenanceItem);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when the insert succeeds', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(maintenanceItemDTO);
+        });
+
+        it('calls executeQuery', async () => {
+          await addMaintenanceItem(maintenanceItem);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('inserts into the maintenance_items table', async () => {
+          await addMaintenanceItem(maintenanceItem);
+          expect(mockFrom).toHaveBeenCalledWith('maintenance_items');
+        });
+
+        it('returns the converted maintenance item', async () => {
+          expect(await addMaintenanceItem(maintenanceItem)).toEqual(maintenanceItem);
+        });
+      });
+
+      describe('when the insert fails', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns null', async () => {
+          expect(await addMaintenanceItem(maintenanceItem)).toBeNull();
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // canDeleteMaintenanceItem
+  // ---------------------------------------------------------------------------
+
+  describe('canDeleteMaintenanceItem', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns false', async () => {
+        expect(await canDeleteMaintenanceItem(maintenanceItem)).toBe(false);
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      it('returns true', async () => {
+        expect(await canDeleteMaintenanceItem(maintenanceItem)).toBe(true);
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // deleteMaintenanceItem
+  // ---------------------------------------------------------------------------
+
+  describe('deleteMaintenanceItem', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('does not access the database', async () => {
+        await deleteMaintenanceItem(maintenanceItem);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+        (executeQuery as Mock).mockResolvedValue(null);
+      });
+
+      it('calls executeQuery', async () => {
+        await deleteMaintenanceItem(maintenanceItem);
+        expect(executeQuery).toHaveBeenCalledOnce();
+      });
+
+      it('deletes from the maintenance_items table', async () => {
+        await deleteMaintenanceItem(maintenanceItem);
+        expect(mockFrom).toHaveBeenCalledWith('maintenance_items');
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // updateMaintenanceItem
+  // ---------------------------------------------------------------------------
+
+  describe('updateMaintenanceItem', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns null', async () => {
+        expect(await updateMaintenanceItem(maintenanceItem)).toBeNull();
+      });
+
+      it('does not access the database', async () => {
+        await updateMaintenanceItem(maintenanceItem);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when the update succeeds', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(maintenanceItemDTO);
+        });
+
+        it('calls executeQuery', async () => {
+          await updateMaintenanceItem(maintenanceItem);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('updates the maintenance_items table', async () => {
+          await updateMaintenanceItem(maintenanceItem);
+          expect(mockFrom).toHaveBeenCalledWith('maintenance_items');
+        });
+
+        it('returns the converted maintenance item', async () => {
+          expect(await updateMaintenanceItem(maintenanceItem)).toEqual(maintenanceItem);
+        });
+      });
+
+      describe('when the update fails', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns null', async () => {
+          expect(await updateMaintenanceItem(maintenanceItem)).toBeNull();
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // fetchMaintenanceTypes
+  // ---------------------------------------------------------------------------
+
+  describe('fetchMaintenanceTypes', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns an empty array', async () => {
+        expect(await fetchMaintenanceTypes()).toEqual([]);
+      });
+
+      it('does not access the database', async () => {
+        await fetchMaintenanceTypes();
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue([maintenanceTypeDTO]);
+        });
+
+        it('calls executeQuery', async () => {
+          await fetchMaintenanceTypes();
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('queries the maintenance_types table', async () => {
+          await fetchMaintenanceTypes();
+          expect(mockFrom).toHaveBeenCalledWith('maintenance_types');
+        });
+
+        it('returns the converted maintenance types', async () => {
+          expect(await fetchMaintenanceTypes()).toEqual([
+            { id: 2, name: 'Periodic Maintenance', description: 'Oil change etc.' },
+          ]);
+        });
+      });
+
+      describe('when no data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns an empty array', async () => {
+          expect(await fetchMaintenanceTypes()).toEqual([]);
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // fetchUsageUnits
+  // ---------------------------------------------------------------------------
+
+  describe('fetchUsageUnits', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns an empty array', async () => {
+        expect(await fetchUsageUnits()).toEqual([]);
+      });
+
+      it('does not access the database', async () => {
+        await fetchUsageUnits();
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue([usageUnitsDTO]);
+        });
+
+        it('calls executeQuery', async () => {
+          await fetchUsageUnits();
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('queries the usage_units table', async () => {
+          await fetchUsageUnits();
+          expect(mockFrom).toHaveBeenCalledWith('usage_units');
+        });
+
+        it('returns the converted usage units', async () => {
+          expect(await fetchUsageUnits()).toEqual([{ id: 1, name: 'Miles' }]);
+        });
+      });
+
+      describe('when no data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns an empty array', async () => {
+          expect(await fetchUsageUnits()).toEqual([]);
+        });
+      });
+    });
+  });
+});

--- a/app/adventure/equipment/create/__tests__/actions.spec.ts
+++ b/app/adventure/equipment/create/__tests__/actions.spec.ts
@@ -1,0 +1,60 @@
+import { Equipment } from '@/models';
+import { redirect } from 'next/navigation';
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { addEquipment } from '../../data';
+import { createEquipmentConfirmed } from '../actions';
+
+vi.mock('../../data');
+vi.mock('next/navigation');
+
+const equipment: Equipment = {
+  id: 0,
+  name: 'Test Kayak',
+  description: 'A kayak for testing',
+  purchaseDate: null,
+  cost: null,
+  manufacturer: null,
+  model: null,
+  identification: null,
+  length: null,
+  weight: null,
+  capacity: null,
+  licensePlateNumber: null,
+  insuranceCarrier: null,
+  insurancePolicyNumber: null,
+  insuranceContactName: null,
+  insuranceContactPhoneNumber: null,
+  insuranceContactEmail: null,
+  equipmentType: { id: 1, name: 'Kayak', description: 'A small boat' },
+};
+
+describe('equipment: createEquipmentConfirmed', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls addEquipment with the provided equipment', async () => {
+    await createEquipmentConfirmed(equipment).catch(() => {});
+    expect(addEquipment).toHaveBeenCalledExactlyOnceWith(equipment);
+  });
+
+  describe('when addEquipment succeeds', () => {
+    beforeEach(() => {
+      (addEquipment as Mock).mockResolvedValue({ ...equipment, id: 42 });
+    });
+
+    it('redirects to /adventure/equipment', async () => {
+      await createEquipmentConfirmed(equipment).catch(() => {});
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/equipment');
+    });
+  });
+
+  describe('when addEquipment fails', () => {
+    beforeEach(() => {
+      (addEquipment as Mock).mockResolvedValue(null);
+    });
+
+    it('redirects to /error', async () => {
+      await createEquipmentConfirmed(equipment).catch(() => {});
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
+    });
+  });
+});

--- a/app/adventure/events/[id]/delete/__tests__/actions.spec.ts
+++ b/app/adventure/events/[id]/delete/__tests__/actions.spec.ts
@@ -1,0 +1,65 @@
+import { Event } from '@/models';
+import { EVENTS } from '@/app/adventure/events/__mocks__/data';
+import { describe, beforeEach, vi, it, expect } from 'vitest';
+import { deleteAborted, deleteConfirmed } from '../actions';
+import { deleteEvent } from '@/app/adventure/events/data';
+import { redirect } from 'next/navigation';
+
+vi.mock('@/app/adventure/events/data');
+vi.mock('next/navigation');
+
+const event: Event = EVENTS.find((e) => e.id === 1)!;
+
+describe('events: delete actions', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe('deleteConfirmed', () => {
+    it('calls deleteEvent', async () => {
+      await deleteConfirmed(event, 'Home');
+      expect(deleteEvent).toHaveBeenCalledExactlyOnceWith(event);
+    });
+
+    it.each([
+      {
+        page: 'Home',
+        expected: '/adventure',
+      },
+      {
+        page: 'Event',
+        expected: '/adventure/events',
+      },
+      {
+        page: 'Default',
+        expected: '/adventure/events',
+      },
+    ])('redirects to the $page page', async ({ page, expected }) => {
+      await deleteConfirmed(event, page);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith(expected);
+    });
+  });
+
+  describe('deleteAborted', () => {
+    it('does not call deleteEvent', async () => {
+      await deleteAborted('Home');
+      expect(deleteEvent).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      {
+        page: 'Home',
+        expected: '/adventure',
+      },
+      {
+        page: 'Event',
+        expected: '/adventure/events',
+      },
+      {
+        page: 'Default',
+        expected: '/adventure/events',
+      },
+    ])('redirects to the $page page', async ({ page, expected }) => {
+      await deleteAborted(page);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith(expected);
+    });
+  });
+});

--- a/app/adventure/events/[id]/itinerary/[itineraryItemId]/delete/__tests__/actions.spec.ts
+++ b/app/adventure/events/[id]/itinerary/[itineraryItemId]/delete/__tests__/actions.spec.ts
@@ -1,0 +1,39 @@
+import { ItineraryItem } from '@/models';
+import { ITINERARY_ITEMS } from '@/app/adventure/events/[id]/itinerary/__mocks__/data';
+import { redirect } from 'next/navigation';
+import { describe, beforeEach, vi, it, expect } from 'vitest';
+import { deleteConfirmed, deleteAborted } from '../actions';
+import { deleteItineraryItem } from '@/app/adventure/events/[id]/itinerary/data';
+
+vi.mock('@/app/adventure/events/[id]/itinerary/data');
+vi.mock('next/navigation');
+
+const itineraryItem: ItineraryItem = ITINERARY_ITEMS.find((i) => i.id === 1)!;
+
+describe('itinerary item delete actions', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe('deleteConfirmed', () => {
+    it('calls deleteItineraryItem with the specified item', async () => {
+      await deleteConfirmed(103, itineraryItem);
+      expect(deleteItineraryItem).toHaveBeenCalledExactlyOnceWith(itineraryItem);
+    });
+
+    it('redirects to the event details page', async () => {
+      await deleteConfirmed(103, itineraryItem);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/events/103?lastActivity=Itinerary');
+    });
+  });
+
+  describe('deleteAborted', () => {
+    it('does not call deleteItineraryItem', async () => {
+      await deleteAborted(103);
+      expect(deleteItineraryItem).not.toHaveBeenCalled();
+    });
+
+    it('redirects to the event details page', async () => {
+      await deleteAborted(103);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/events/103?lastActivity=Itinerary');
+    });
+  });
+});

--- a/app/adventure/events/[id]/itinerary/[itineraryItemId]/update/__tests__/actions.spec.ts
+++ b/app/adventure/events/[id]/itinerary/[itineraryItemId]/update/__tests__/actions.spec.ts
@@ -1,0 +1,42 @@
+import { ItineraryItem } from '@/models';
+import { ITINERARY_ITEMS } from '@/app/adventure/events/[id]/itinerary/__mocks__/data';
+import { redirect } from 'next/navigation';
+import { describe, beforeEach, vi, it, expect } from 'vitest';
+import { updateConfirmed } from '../actions';
+import { updateItineraryItem } from '@/app/adventure/events/[id]/itinerary/data';
+
+vi.mock('@/app/adventure/events/[id]/itinerary/data');
+vi.mock('next/navigation');
+
+const itineraryItem: ItineraryItem = { ...ITINERARY_ITEMS.find((i) => i.id === 1)!, eventRid: 17 };
+
+describe('itinerary item updateConfirmed', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls updateItineraryItem with the specified itinerary item', async () => {
+    await updateConfirmed(itineraryItem);
+    expect(updateItineraryItem).toHaveBeenCalledExactlyOnceWith(itineraryItem);
+  });
+
+  describe('when updateItineraryItem succeeds', () => {
+    beforeEach(() => {
+      (updateItineraryItem as any).mockResolvedValue(itineraryItem);
+    });
+
+    it('redirects to the event details page', async () => {
+      await updateConfirmed(itineraryItem);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/events/17?lastActivity=Itinerary');
+    });
+  });
+
+  describe('when updateItineraryItem fails', () => {
+    beforeEach(() => {
+      (updateItineraryItem as any).mockResolvedValue(null);
+    });
+
+    it('redirects to /error', async () => {
+      await updateConfirmed(itineraryItem);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
+    });
+  });
+});

--- a/app/adventure/events/[id]/itinerary/[itineraryItemId]/update/__tests__/actions.spec.ts
+++ b/app/adventure/events/[id]/itinerary/[itineraryItemId]/update/__tests__/actions.spec.ts
@@ -1,9 +1,9 @@
-import { ItineraryItem } from '@/models';
 import { ITINERARY_ITEMS } from '@/app/adventure/events/[id]/itinerary/__mocks__/data';
-import { redirect } from 'next/navigation';
-import { describe, beforeEach, vi, it, expect } from 'vitest';
-import { updateConfirmed } from '../actions';
 import { updateItineraryItem } from '@/app/adventure/events/[id]/itinerary/data';
+import { ItineraryItem } from '@/models';
+import { redirect } from 'next/navigation';
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { updateConfirmed } from '../actions';
 
 vi.mock('@/app/adventure/events/[id]/itinerary/data');
 vi.mock('next/navigation');
@@ -20,7 +20,7 @@ describe('itinerary item updateConfirmed', () => {
 
   describe('when updateItineraryItem succeeds', () => {
     beforeEach(() => {
-      (updateItineraryItem as any).mockResolvedValue(itineraryItem);
+      (updateItineraryItem as Mock).mockResolvedValue(itineraryItem);
     });
 
     it('redirects to the event details page', async () => {
@@ -31,7 +31,7 @@ describe('itinerary item updateConfirmed', () => {
 
   describe('when updateItineraryItem fails', () => {
     beforeEach(() => {
-      (updateItineraryItem as any).mockResolvedValue(null);
+      (updateItineraryItem as Mock).mockResolvedValue(null);
     });
 
     it('redirects to /error', async () => {

--- a/app/adventure/events/[id]/itinerary/__tests__/data.spec.ts
+++ b/app/adventure/events/[id]/itinerary/__tests__/data.spec.ts
@@ -53,6 +53,7 @@ describe('itinerary data', () => {
     vi.clearAllMocks();
     const chain = buildChainableMock();
     mockFrom = vi.fn().mockReturnValue(chain);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vi.mocked(createClient).mockReturnValue({ from: mockFrom } as any);
   });
 

--- a/app/adventure/events/[id]/itinerary/__tests__/data.spec.ts
+++ b/app/adventure/events/[id]/itinerary/__tests__/data.spec.ts
@@ -1,0 +1,293 @@
+import { executeQuery } from '@/utils/data';
+import { isNotLoggedIn } from '@/utils/supabase/auth';
+import { createClient } from '@/utils/supabase/server';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import {
+  addItineraryItem,
+  canDeleteItineraryItem,
+  deleteItineraryItem,
+  fetchItineraryItem,
+  updateItineraryItem,
+} from '../data';
+
+vi.mock('@/utils/supabase/auth');
+vi.mock('@/utils/supabase/server');
+vi.mock('@/utils/data', () => ({ executeQuery: vi.fn() }));
+
+// --- Test data ---
+
+const itineraryItemDTO = {
+  id: 1,
+  name: 'Set up the campsite',
+  description: 'I will concentrate on the outside, Lisa the inside.',
+  date: '2025-07-03',
+  time: '15:00',
+  event_rid: 14,
+};
+
+const itineraryItem = {
+  id: 1,
+  name: 'Set up the campsite',
+  description: 'I will concentrate on the outside, Lisa the inside.',
+  date: '2025-07-03',
+  time: '15:00',
+  eventRid: 14,
+};
+
+// --- Helpers ---
+
+const buildChainableMock = () => {
+  const chain: Record<string, Mock> = {};
+  ['select', 'insert', 'update', 'delete', 'eq', 'single'].forEach((method) => {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  });
+  return chain;
+};
+
+// --- Tests ---
+
+describe('itinerary data', () => {
+  let mockFrom: Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const chain = buildChainableMock();
+    mockFrom = vi.fn().mockReturnValue(chain);
+    vi.mocked(createClient).mockReturnValue({ from: mockFrom } as any);
+  });
+
+  // ---------------------------------------------------------------------------
+  // fetchItineraryItem
+  // ---------------------------------------------------------------------------
+
+  describe('fetchItineraryItem', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns null', async () => {
+        expect(await fetchItineraryItem(1)).toBeNull();
+      });
+
+      it('does not access the database', async () => {
+        await fetchItineraryItem(1);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(itineraryItemDTO);
+        });
+
+        it('calls executeQuery', async () => {
+          await fetchItineraryItem(1);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('queries the itinerary_items table', async () => {
+          await fetchItineraryItem(1);
+          expect(mockFrom).toHaveBeenCalledWith('itinerary_items');
+        });
+
+        it('returns the converted itinerary item', async () => {
+          expect(await fetchItineraryItem(1)).toEqual(itineraryItem);
+        });
+      });
+
+      describe('when no data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns null', async () => {
+          expect(await fetchItineraryItem(1)).toBeNull();
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // addItineraryItem
+  // ---------------------------------------------------------------------------
+
+  describe('addItineraryItem', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns null', async () => {
+        expect(await addItineraryItem(itineraryItem)).toBeNull();
+      });
+
+      it('does not access the database', async () => {
+        await addItineraryItem(itineraryItem);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when the insert succeeds', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(itineraryItemDTO);
+        });
+
+        it('calls executeQuery', async () => {
+          await addItineraryItem(itineraryItem);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('inserts into the itinerary_items table', async () => {
+          await addItineraryItem(itineraryItem);
+          expect(mockFrom).toHaveBeenCalledWith('itinerary_items');
+        });
+
+        it('returns the converted itinerary item', async () => {
+          expect(await addItineraryItem(itineraryItem)).toEqual(itineraryItem);
+        });
+      });
+
+      describe('when the insert fails', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns null', async () => {
+          expect(await addItineraryItem(itineraryItem)).toBeNull();
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // canDeleteItineraryItem
+  // ---------------------------------------------------------------------------
+
+  describe('canDeleteItineraryItem', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns false', async () => {
+        expect(await canDeleteItineraryItem(itineraryItem)).toBe(false);
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      it('returns true', async () => {
+        expect(await canDeleteItineraryItem(itineraryItem)).toBe(true);
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // deleteItineraryItem
+  // ---------------------------------------------------------------------------
+
+  describe('deleteItineraryItem', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('does not access the database', async () => {
+        await deleteItineraryItem(itineraryItem);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+        (executeQuery as Mock).mockResolvedValue(null);
+      });
+
+      it('calls executeQuery', async () => {
+        await deleteItineraryItem(itineraryItem);
+        expect(executeQuery).toHaveBeenCalledOnce();
+      });
+
+      it('deletes from the itinerary_items table', async () => {
+        await deleteItineraryItem(itineraryItem);
+        expect(mockFrom).toHaveBeenCalledWith('itinerary_items');
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // updateItineraryItem
+  // ---------------------------------------------------------------------------
+
+  describe('updateItineraryItem', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns null', async () => {
+        expect(await updateItineraryItem(itineraryItem)).toBeNull();
+      });
+
+      it('does not access the database', async () => {
+        await updateItineraryItem(itineraryItem);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when the update succeeds', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(itineraryItemDTO);
+        });
+
+        it('calls executeQuery', async () => {
+          await updateItineraryItem(itineraryItem);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('updates the itinerary_items table', async () => {
+          await updateItineraryItem(itineraryItem);
+          expect(mockFrom).toHaveBeenCalledWith('itinerary_items');
+        });
+
+        it('returns the converted itinerary item', async () => {
+          expect(await updateItineraryItem(itineraryItem)).toEqual(itineraryItem);
+        });
+      });
+
+      describe('when the update fails', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns null', async () => {
+          expect(await updateItineraryItem(itineraryItem)).toBeNull();
+        });
+      });
+    });
+  });
+});

--- a/app/adventure/events/[id]/itinerary/create/__tests__/actions.spec.ts
+++ b/app/adventure/events/[id]/itinerary/create/__tests__/actions.spec.ts
@@ -2,7 +2,7 @@ import { ITINERARY_ITEMS } from '@/app/adventure/events/[id]/itinerary/__mocks__
 import { addItineraryItem } from '@/app/adventure/events/[id]/itinerary/data';
 import { ItineraryItem } from '@/models';
 import { redirect } from 'next/navigation';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import { createConfirmed } from '../actions';
 
 vi.mock('@/app/adventure/events/[id]/itinerary/data');
@@ -19,7 +19,7 @@ describe('itinerary: createConfirmed', () => {
 
   describe('when addItineraryItem succeeds', () => {
     beforeEach(() => {
-      (addItineraryItem as any).mockResolvedValue({ ...itineraryItem, id: 73 });
+      (addItineraryItem as Mock).mockResolvedValue({ ...itineraryItem, id: 73 });
     });
 
     it('redirects to the event details page', async () => {
@@ -30,7 +30,7 @@ describe('itinerary: createConfirmed', () => {
 
   describe('when addItineraryItem fails', () => {
     beforeEach(() => {
-      (addItineraryItem as any).mockResolvedValue(null);
+      (addItineraryItem as Mock).mockResolvedValue(null);
     });
 
     it('redirects to /error', async () => {

--- a/app/adventure/events/[id]/itinerary/create/__tests__/actions.spec.ts
+++ b/app/adventure/events/[id]/itinerary/create/__tests__/actions.spec.ts
@@ -1,0 +1,41 @@
+import { ITINERARY_ITEMS } from '@/app/adventure/events/[id]/itinerary/__mocks__/data';
+import { addItineraryItem } from '@/app/adventure/events/[id]/itinerary/data';
+import { ItineraryItem } from '@/models';
+import { redirect } from 'next/navigation';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createConfirmed } from '../actions';
+
+vi.mock('@/app/adventure/events/[id]/itinerary/data');
+vi.mock('next/navigation');
+
+const itineraryItem: ItineraryItem = { ...ITINERARY_ITEMS.find((i) => i.id === 3)!, id: undefined, eventRid: 332 };
+
+describe('itinerary: createConfirmed', () => {
+  beforeEach(() => vi.clearAllMocks());
+  it('calls addItineraryItem with the specified itinerary item', async () => {
+    await createConfirmed(itineraryItem);
+    expect(addItineraryItem).toHaveBeenCalledExactlyOnceWith(itineraryItem);
+  });
+
+  describe('when addItineraryItem succeeds', () => {
+    beforeEach(() => {
+      (addItineraryItem as any).mockResolvedValue({ ...itineraryItem, id: 73 });
+    });
+
+    it('redirects to the event details page', async () => {
+      await createConfirmed(itineraryItem);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/events/332?lastActivity=Itinerary');
+    });
+  });
+
+  describe('when addItineraryItem fails', () => {
+    beforeEach(() => {
+      (addItineraryItem as any).mockResolvedValue(null);
+    });
+
+    it('redirects to /error', async () => {
+      await createConfirmed(itineraryItem);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
+    });
+  });
+});

--- a/app/adventure/events/[id]/notes/[noteId]/delete/__tests__/actions.spec.ts
+++ b/app/adventure/events/[id]/notes/[noteId]/delete/__tests__/actions.spec.ts
@@ -1,0 +1,39 @@
+import { NOTES } from '@/app/adventure/notes/__mocks__/data';
+import { deleteNote } from '@/app/adventure/notes/data';
+import { Note } from '@/models';
+import { redirect } from 'next/navigation';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { deleteAborted, deleteConfirmed } from '../actions';
+
+vi.mock('@/app/adventure/notes/data');
+vi.mock('next/navigation');
+
+const note: Note = NOTES.find((n) => n.eventRid !== null)!;
+
+describe('event notes: delete actions', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe('deleteConfirmed', () => {
+    it('calls deleteNote', async () => {
+      await deleteConfirmed(19, note);
+      expect(deleteNote).toHaveBeenCalledExactlyOnceWith(note);
+    });
+
+    it('redirects to the event details page', async () => {
+      await deleteConfirmed(19, note);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/events/19?lastActivity=Notes');
+    });
+  });
+
+  describe('deleteAborted', () => {
+    it('does not call deleteNote', async () => {
+      await deleteAborted(19);
+      expect(deleteNote).not.toHaveBeenCalled();
+    });
+
+    it('redirects to the event details page', async () => {
+      await deleteAborted(19);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/events/19?lastActivity=Notes');
+    });
+  });
+});

--- a/app/adventure/events/[id]/notes/[noteId]/update/__tests__/actions.spec.ts
+++ b/app/adventure/events/[id]/notes/[noteId]/update/__tests__/actions.spec.ts
@@ -1,0 +1,42 @@
+import { NOTES } from '@/app/adventure/notes/__mocks__/data';
+import { updateNote } from '@/app/adventure/notes/data';
+import { Note } from '@/models';
+import { redirect } from 'next/navigation';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { updateConfirmed } from '../actions';
+
+vi.mock('@/app/adventure/notes/data');
+vi.mock('next/navigation');
+
+const note: Note = { ...NOTES.find((n) => n.eventRid !== null)!, eventRid: 14 };
+
+describe('event notes: updateConfirmed', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls updateNote with the specified note', async () => {
+    await updateConfirmed(note);
+    expect(updateNote).toHaveBeenCalledExactlyOnceWith(note);
+  });
+
+  describe('when updateNote succeeds', () => {
+    beforeEach(() => {
+      (updateNote as any).mockResolvedValue(note);
+    });
+
+    it('redirects to the event details page', async () => {
+      await updateConfirmed(note);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/events/14?lastActivity=Notes');
+    });
+  });
+
+  describe('when updateNote fails', () => {
+    beforeEach(() => {
+      (updateNote as any).mockResolvedValue(null);
+    });
+
+    it('redirects to /error', async () => {
+      await updateConfirmed(note);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
+    });
+  });
+});

--- a/app/adventure/events/[id]/notes/[noteId]/update/__tests__/actions.spec.ts
+++ b/app/adventure/events/[id]/notes/[noteId]/update/__tests__/actions.spec.ts
@@ -2,7 +2,7 @@ import { NOTES } from '@/app/adventure/notes/__mocks__/data';
 import { updateNote } from '@/app/adventure/notes/data';
 import { Note } from '@/models';
 import { redirect } from 'next/navigation';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import { updateConfirmed } from '../actions';
 
 vi.mock('@/app/adventure/notes/data');
@@ -20,7 +20,7 @@ describe('event notes: updateConfirmed', () => {
 
   describe('when updateNote succeeds', () => {
     beforeEach(() => {
-      (updateNote as any).mockResolvedValue(note);
+      (updateNote as Mock).mockResolvedValue(note);
     });
 
     it('redirects to the event details page', async () => {
@@ -31,7 +31,7 @@ describe('event notes: updateConfirmed', () => {
 
   describe('when updateNote fails', () => {
     beforeEach(() => {
-      (updateNote as any).mockResolvedValue(null);
+      (updateNote as Mock).mockResolvedValue(null);
     });
 
     it('redirects to /error', async () => {

--- a/app/adventure/events/[id]/notes/create/__tests__/actions.spec.ts
+++ b/app/adventure/events/[id]/notes/create/__tests__/actions.spec.ts
@@ -2,7 +2,7 @@ import { NOTES } from '@/app/adventure/notes/__mocks__/data';
 import { addNote } from '@/app/adventure/notes/data';
 import { Note } from '@/models';
 import { redirect } from 'next/navigation';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import { createConfirmed } from '../actions';
 
 vi.mock('@/app/adventure/notes/data');
@@ -20,7 +20,7 @@ describe('event notes: createConfirmed', () => {
 
   describe('when addNote succeeds', () => {
     beforeEach(() => {
-      (addNote as any).mockResolvedValue({ ...note, id: 73 });
+      (addNote as Mock).mockResolvedValue({ ...note, id: 73 });
     });
 
     it('redirects to the event details page', async () => {
@@ -31,7 +31,7 @@ describe('event notes: createConfirmed', () => {
 
   describe('when addNote fails', () => {
     beforeEach(() => {
-      (addNote as any).mockResolvedValue(null);
+      (addNote as Mock).mockResolvedValue(null);
     });
 
     it('redirects to /error', async () => {

--- a/app/adventure/events/[id]/notes/create/__tests__/actions.spec.ts
+++ b/app/adventure/events/[id]/notes/create/__tests__/actions.spec.ts
@@ -1,0 +1,42 @@
+import { NOTES } from '@/app/adventure/notes/__mocks__/data';
+import { addNote } from '@/app/adventure/notes/data';
+import { Note } from '@/models';
+import { redirect } from 'next/navigation';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createConfirmed } from '../actions';
+
+vi.mock('@/app/adventure/notes/data');
+vi.mock('next/navigation');
+
+const note: Note = { ...NOTES.find((n) => n.eventRid !== null)!, id: undefined, eventRid: 19 };
+
+describe('event notes: createConfirmed', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls addNote with the specified note', async () => {
+    await createConfirmed(note);
+    expect(addNote).toHaveBeenCalledExactlyOnceWith(note);
+  });
+
+  describe('when addNote succeeds', () => {
+    beforeEach(() => {
+      (addNote as any).mockResolvedValue({ ...note, id: 73 });
+    });
+
+    it('redirects to the event details page', async () => {
+      await createConfirmed(note);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/events/19?lastActivity=Notes');
+    });
+  });
+
+  describe('when addNote fails', () => {
+    beforeEach(() => {
+      (addNote as any).mockResolvedValue(null);
+    });
+
+    it('redirects to /error', async () => {
+      await createConfirmed(note);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
+    });
+  });
+});

--- a/app/adventure/events/[id]/todos/[collectionId]/delete/__tests__/actions.spec.ts
+++ b/app/adventure/events/[id]/todos/[collectionId]/delete/__tests__/actions.spec.ts
@@ -1,0 +1,39 @@
+import { TODO_COLLECTIONS } from '@/app/adventure/todos/__mocks__/data';
+import { TodoCollection } from '@/models';
+import { redirect } from 'next/navigation';
+import { describe, beforeEach, vi, it, expect } from 'vitest';
+import { deleteConfirmed, deleteAborted } from '../actions';
+import { deleteTodoCollection } from '@/app/adventure/todos/data';
+
+vi.mock('@/app/adventure/todos/data');
+vi.mock('next/navigation');
+
+const todos: TodoCollection = TODO_COLLECTIONS.find((c) => c.eventRid !== null)!;
+
+describe('event todos: delete actions', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe('deleteConfirmed', () => {
+    it('calls deleteTodoCollection', async () => {
+      await deleteConfirmed(324, todos);
+      expect(deleteTodoCollection).toHaveBeenCalledExactlyOnceWith(todos);
+    });
+
+    it('redirects to the event details page', async () => {
+      await deleteConfirmed(324, todos);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/events/324?lastActivity=Todos');
+    });
+  });
+
+  describe('deleteAborted', () => {
+    it('does not call deleteTodoCollection', async () => {
+      await deleteAborted(324);
+      expect(deleteTodoCollection).not.toHaveBeenCalled();
+    });
+
+    it('redirects to the event details page', async () => {
+      await deleteAborted(324);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/events/324?lastActivity=Todos');
+    });
+  });
+});

--- a/app/adventure/events/[id]/todos/[collectionId]/update/__tests__/actions.spec.ts
+++ b/app/adventure/events/[id]/todos/[collectionId]/update/__tests__/actions.spec.ts
@@ -1,9 +1,9 @@
 import { TODO_COLLECTIONS } from '@/app/adventure/todos/__mocks__/data';
+import { updateTodoCollection } from '@/app/adventure/todos/data';
 import { TodoCollection } from '@/models';
 import { redirect } from 'next/navigation';
-import { describe, beforeEach, vi, it, expect } from 'vitest';
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 import { updateConfirmed } from '../actions';
-import { updateTodoCollection } from '@/app/adventure/todos/data';
 
 vi.mock('@/app/adventure/todos/data');
 vi.mock('next/navigation');
@@ -20,7 +20,7 @@ describe('event todos: updateConfirmed', () => {
 
   describe('when the update succeeds', () => {
     beforeEach(() => {
-      (updateTodoCollection as any).mockResolvedValue({ ...todos, id: 73 });
+      (updateTodoCollection as Mock).mockResolvedValue({ ...todos, id: 73 });
     });
 
     it('redirects to the event details page', async () => {
@@ -31,7 +31,7 @@ describe('event todos: updateConfirmed', () => {
 
   describe('when the update fails', () => {
     beforeEach(() => {
-      (updateTodoCollection as any).mockResolvedValue(null);
+      (updateTodoCollection as Mock).mockResolvedValue(null);
     });
 
     it('redirects to /error', async () => {

--- a/app/adventure/events/[id]/todos/[collectionId]/update/__tests__/actions.spec.ts
+++ b/app/adventure/events/[id]/todos/[collectionId]/update/__tests__/actions.spec.ts
@@ -1,0 +1,42 @@
+import { TODO_COLLECTIONS } from '@/app/adventure/todos/__mocks__/data';
+import { TodoCollection } from '@/models';
+import { redirect } from 'next/navigation';
+import { describe, beforeEach, vi, it, expect } from 'vitest';
+import { updateConfirmed } from '../actions';
+import { updateTodoCollection } from '@/app/adventure/todos/data';
+
+vi.mock('@/app/adventure/todos/data');
+vi.mock('next/navigation');
+
+const todos: TodoCollection = { ...TODO_COLLECTIONS.find((c) => c.eventRid !== null)!, id: undefined, eventRid: 58 };
+
+describe('event todos: updateConfirmed', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls updateTodoCollection with the specified todo collection', async () => {
+    await updateConfirmed(todos);
+    expect(updateTodoCollection).toHaveBeenCalledExactlyOnceWith(todos);
+  });
+
+  describe('when the update succeeds', () => {
+    beforeEach(() => {
+      (updateTodoCollection as any).mockResolvedValue({ ...todos, id: 73 });
+    });
+
+    it('redirects to the event details page', async () => {
+      await updateConfirmed(todos);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/events/58?lastActivity=Todos');
+    });
+  });
+
+  describe('when the update fails', () => {
+    beforeEach(() => {
+      (updateTodoCollection as any).mockResolvedValue(null);
+    });
+
+    it('redirects to /error', async () => {
+      await updateConfirmed(todos);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
+    });
+  });
+});

--- a/app/adventure/events/[id]/todos/create/__tests__/actions.spec.ts
+++ b/app/adventure/events/[id]/todos/create/__tests__/actions.spec.ts
@@ -1,0 +1,42 @@
+import { TODO_COLLECTIONS } from '@/app/adventure/todos/__mocks__/data';
+import { addTodoCollection } from '@/app/adventure/todos/data';
+import { TodoCollection } from '@/models';
+import { redirect } from 'next/navigation';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createConfirmed } from '../actions';
+
+vi.mock('@/app/adventure/todos/data');
+vi.mock('next/navigation');
+
+const todos: TodoCollection = { ...TODO_COLLECTIONS.find((c) => c.eventRid !== null)!, id: undefined, eventRid: 58 };
+
+describe('event todos: createConfirmed', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls addTodoCollection with the specified todo collection', async () => {
+    await createConfirmed(todos);
+    expect(addTodoCollection).toHaveBeenCalledExactlyOnceWith(todos);
+  });
+
+  describe('when addTodoCollection succeeds', () => {
+    beforeEach(() => {
+      (addTodoCollection as any).mockResolvedValue({ ...todos, id: 73 });
+    });
+
+    it('redirects to the event details page', async () => {
+      await createConfirmed(todos);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/events/58?lastActivity=Todos');
+    });
+  });
+
+  describe('when addTodoCollection fails', () => {
+    beforeEach(() => {
+      (addTodoCollection as any).mockResolvedValue(null);
+    });
+
+    it('redirects to /error', async () => {
+      await createConfirmed(todos);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
+    });
+  });
+});

--- a/app/adventure/events/[id]/todos/create/__tests__/actions.spec.ts
+++ b/app/adventure/events/[id]/todos/create/__tests__/actions.spec.ts
@@ -2,7 +2,7 @@ import { TODO_COLLECTIONS } from '@/app/adventure/todos/__mocks__/data';
 import { addTodoCollection } from '@/app/adventure/todos/data';
 import { TodoCollection } from '@/models';
 import { redirect } from 'next/navigation';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import { createConfirmed } from '../actions';
 
 vi.mock('@/app/adventure/todos/data');
@@ -20,7 +20,7 @@ describe('event todos: createConfirmed', () => {
 
   describe('when addTodoCollection succeeds', () => {
     beforeEach(() => {
-      (addTodoCollection as any).mockResolvedValue({ ...todos, id: 73 });
+      (addTodoCollection as Mock).mockResolvedValue({ ...todos, id: 73 });
     });
 
     it('redirects to the event details page', async () => {
@@ -31,7 +31,7 @@ describe('event todos: createConfirmed', () => {
 
   describe('when addTodoCollection fails', () => {
     beforeEach(() => {
-      (addTodoCollection as any).mockResolvedValue(null);
+      (addTodoCollection as Mock).mockResolvedValue(null);
     });
 
     it('redirects to /error', async () => {

--- a/app/adventure/events/[id]/update/__tests__/actions.spec.ts
+++ b/app/adventure/events/[id]/update/__tests__/actions.spec.ts
@@ -1,0 +1,55 @@
+import { Event } from '@/models';
+import { describe, beforeEach, vi, it, expect } from 'vitest';
+import { EVENTS } from '@/app/adventure/events/__mocks__/data';
+import { updateConfirmed } from '../actions';
+import { redirect } from 'next/navigation';
+import { updateEvent } from '@/app/adventure/events/data';
+
+vi.mock('@/app/adventure/events/data');
+vi.mock('next/navigation');
+
+const event: Event = EVENTS.find((e) => e.id === 2)!;
+
+describe('events: updateConfirmed', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls updateEvent with the specified event', async () => {
+    await updateConfirmed(event, 'Home');
+    expect(updateEvent).toHaveBeenCalledExactlyOnceWith(event);
+  });
+
+  describe('when the update succeeds', () => {
+    beforeEach(() => {
+      (updateEvent as any).mockResolvedValue(event);
+    });
+
+    it.each([
+      {
+        page: 'Home',
+        expected: '/adventure',
+      },
+      {
+        page: 'Event',
+        expected: '/adventure/events',
+      },
+      {
+        page: 'Default',
+        expected: '/adventure/events',
+      },
+    ])('redirects to the $page page', async ({ page, expected }) => {
+      await updateConfirmed(event, page);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith(expected);
+    });
+  });
+
+  describe('when the update does not succeed', () => {
+    beforeEach(() => {
+      (updateEvent as any).mockResolvedValue(null);
+    });
+
+    it('redirects to /error', async () => {
+      await updateConfirmed(event, 'Home');
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
+    });
+  });
+});

--- a/app/adventure/events/[id]/update/__tests__/actions.spec.ts
+++ b/app/adventure/events/[id]/update/__tests__/actions.spec.ts
@@ -1,5 +1,5 @@
 import { Event } from '@/models';
-import { describe, beforeEach, vi, it, expect } from 'vitest';
+import { describe, beforeEach, vi, it, expect, type Mock } from 'vitest';
 import { EVENTS } from '@/app/adventure/events/__mocks__/data';
 import { updateConfirmed } from '../actions';
 import { redirect } from 'next/navigation';
@@ -20,7 +20,7 @@ describe('events: updateConfirmed', () => {
 
   describe('when the update succeeds', () => {
     beforeEach(() => {
-      (updateEvent as any).mockResolvedValue(event);
+      (updateEvent as Mock).mockResolvedValue(event);
     });
 
     it.each([
@@ -44,7 +44,7 @@ describe('events: updateConfirmed', () => {
 
   describe('when the update does not succeed', () => {
     beforeEach(() => {
-      (updateEvent as any).mockResolvedValue(null);
+      (updateEvent as Mock).mockResolvedValue(null);
     });
 
     it('redirects to /error', async () => {

--- a/app/adventure/events/__mocks__/data.ts
+++ b/app/adventure/events/__mocks__/data.ts
@@ -73,3 +73,4 @@ export const addEvent = vi.fn();
 export const deleteEvent = vi.fn();
 export const canDeleteEvent = vi.fn().mockResolvedValue(false);
 export const fetchEventTypes = vi.fn().mockResolvedValue(EVENT_TYPES);
+export const updateEvent = vi.fn().mockResolvedValue(null);

--- a/app/adventure/events/__tests__/data.spec.ts
+++ b/app/adventure/events/__tests__/data.spec.ts
@@ -105,6 +105,7 @@ describe('events data', () => {
     vi.clearAllMocks();
     const chain = buildChainableMock();
     mockFrom = vi.fn().mockReturnValue(chain);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vi.mocked(createClient).mockReturnValue({ from: mockFrom } as any);
   });
 

--- a/app/adventure/events/__tests__/data.spec.ts
+++ b/app/adventure/events/__tests__/data.spec.ts
@@ -1,0 +1,593 @@
+import { executeQuery } from '@/utils/data';
+import { isNotLoggedIn } from '@/utils/supabase/auth';
+import { createClient } from '@/utils/supabase/server';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import {
+  addEvent,
+  canDeleteEvent,
+  deleteEvent,
+  fetchEvent,
+  fetchEventTypes,
+  fetchLatestEvents,
+  fetchPriorEvents,
+  fetchUpcomingEvents,
+  updateEvent,
+} from '../data';
+
+vi.mock('@/utils/supabase/auth');
+vi.mock('@/utils/supabase/server');
+vi.mock('@/utils/data', () => ({ executeQuery: vi.fn() }));
+
+// --- Test data ---
+
+const placeTypeDTO = { id: 3, name: 'Sports Arena', description: 'Go sports!!' };
+
+const placeDTO = {
+  id: 4,
+  name: 'LaBahn Arena',
+  description: null,
+  address_line_1: '105 East Campus Mall',
+  address_line_2: null,
+  city: 'Madison',
+  state: 'WI',
+  postal_code: '53715',
+  phone_number: null,
+  website: null,
+  place_type_rid: 3,
+  place_types: placeTypeDTO,
+};
+
+const eventTypeDTO = {
+  id: 2,
+  name: 'Sporting Event',
+  description: 'The primary purpose of the activity is to view a competition.',
+};
+
+const eventDTO = {
+  id: 1,
+  name: "Women's Hockey Tournament",
+  description: 'A three day long tournament of women playing hockey',
+  begin_date: '2024-09-28',
+  begin_time: '18:30',
+  end_date: '2024-09-30',
+  end_time: '22:30',
+  place_rid: 4,
+  event_type_rid: 2,
+  places: placeDTO,
+  event_types: eventTypeDTO,
+};
+
+const event = {
+  id: 1,
+  name: "Women's Hockey Tournament",
+  description: 'A three day long tournament of women playing hockey',
+  beginDate: '2024-09-28',
+  beginTime: '18:30',
+  endDate: '2024-09-30',
+  endTime: '22:30',
+  place: {
+    id: 4,
+    name: 'LaBahn Arena',
+    description: null,
+    address: {
+      line1: '105 East Campus Mall',
+      line2: null,
+      city: 'Madison',
+      state: 'WI',
+      postal: '53715',
+    },
+    phoneNumber: null,
+    website: null,
+    type: { id: 3, name: 'Sports Arena', description: 'Go sports!!' },
+  },
+  type: { id: 2, name: 'Sporting Event', description: 'The primary purpose of the activity is to view a competition.' },
+  itinerary: undefined,
+  notes: undefined,
+  todoCollections: undefined,
+};
+
+// --- Helpers ---
+
+const buildChainableMock = () => {
+  const chain: Record<string, Mock> = {};
+  ['select', 'insert', 'update', 'delete', 'eq', 'single', 'order', 'or', 'limit'].forEach((method) => {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  });
+  return chain;
+};
+
+// --- Tests ---
+
+describe('events data', () => {
+  let mockFrom: Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const chain = buildChainableMock();
+    mockFrom = vi.fn().mockReturnValue(chain);
+    vi.mocked(createClient).mockReturnValue({ from: mockFrom } as any);
+  });
+
+  // ---------------------------------------------------------------------------
+  // fetchUpcomingEvents
+  // ---------------------------------------------------------------------------
+
+  describe('fetchUpcomingEvents', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns an empty array', async () => {
+        expect(await fetchUpcomingEvents('2024-01-01')).toEqual([]);
+      });
+
+      it('does not access the database', async () => {
+        await fetchUpcomingEvents('2024-01-01');
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue([eventDTO]);
+        });
+
+        it('calls executeQuery', async () => {
+          await fetchUpcomingEvents('2024-01-01');
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('queries the events table', async () => {
+          await fetchUpcomingEvents('2024-01-01');
+          expect(mockFrom).toHaveBeenCalledWith('events');
+        });
+
+        it('returns the converted events list', async () => {
+          expect(await fetchUpcomingEvents('2024-01-01')).toEqual([event]);
+        });
+
+        it('also queries the events table when an end date is provided', async () => {
+          await fetchUpcomingEvents('2024-01-01', '2024-12-31');
+          expect(mockFrom).toHaveBeenCalledWith('events');
+        });
+      });
+
+      describe('when no data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns an empty array', async () => {
+          expect(await fetchUpcomingEvents('2024-01-01')).toEqual([]);
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // fetchPriorEvents
+  // ---------------------------------------------------------------------------
+
+  describe('fetchPriorEvents', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns an empty array', async () => {
+        expect(await fetchPriorEvents('2024-01-01')).toEqual([]);
+      });
+
+      it('does not access the database', async () => {
+        await fetchPriorEvents('2024-01-01');
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue([eventDTO]);
+        });
+
+        it('calls executeQuery', async () => {
+          await fetchPriorEvents('2024-01-01');
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('queries the events table', async () => {
+          await fetchPriorEvents('2024-01-01');
+          expect(mockFrom).toHaveBeenCalledWith('events');
+        });
+
+        it('returns the converted events list', async () => {
+          expect(await fetchPriorEvents('2024-01-01')).toEqual([event]);
+        });
+      });
+
+      describe('when no data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns an empty array', async () => {
+          expect(await fetchPriorEvents('2024-01-01')).toEqual([]);
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // fetchLatestEvents
+  // ---------------------------------------------------------------------------
+
+  describe('fetchLatestEvents', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns an empty array', async () => {
+        expect(await fetchLatestEvents(5)).toEqual([]);
+      });
+
+      it('does not access the database', async () => {
+        await fetchLatestEvents(5);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue([eventDTO]);
+        });
+
+        it('calls executeQuery', async () => {
+          await fetchLatestEvents(5);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('queries the events table', async () => {
+          await fetchLatestEvents(5);
+          expect(mockFrom).toHaveBeenCalledWith('events');
+        });
+
+        it('returns the converted events list', async () => {
+          expect(await fetchLatestEvents(5)).toEqual([event]);
+        });
+      });
+
+      describe('when no data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns an empty array', async () => {
+          expect(await fetchLatestEvents(5)).toEqual([]);
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // fetchEvent
+  // ---------------------------------------------------------------------------
+
+  describe('fetchEvent', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns null', async () => {
+        expect(await fetchEvent(1)).toBeNull();
+      });
+
+      it('does not access the database', async () => {
+        await fetchEvent(1);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(eventDTO);
+        });
+
+        it('calls executeQuery', async () => {
+          await fetchEvent(1);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('queries the events table', async () => {
+          await fetchEvent(1);
+          expect(mockFrom).toHaveBeenCalledWith('events');
+        });
+
+        it('returns the converted event', async () => {
+          expect(await fetchEvent(1)).toEqual(event);
+        });
+
+        describe('when fetching the full event', () => {
+          it('queries the events table', async () => {
+            await fetchEvent(1, true);
+            expect(mockFrom).toHaveBeenCalledWith('events');
+          });
+
+          it('returns the converted event', async () => {
+            expect(await fetchEvent(1, true)).toEqual(event);
+          });
+        });
+      });
+
+      describe('when no data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns null', async () => {
+          expect(await fetchEvent(1)).toBeNull();
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // addEvent
+  // ---------------------------------------------------------------------------
+
+  describe('addEvent', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns null', async () => {
+        expect(await addEvent(event)).toBeNull();
+      });
+
+      it('does not access the database', async () => {
+        await addEvent(event);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when the insert succeeds', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(eventDTO);
+        });
+
+        it('calls executeQuery', async () => {
+          await addEvent(event);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('inserts into the events table', async () => {
+          await addEvent(event);
+          expect(mockFrom).toHaveBeenCalledWith('events');
+        });
+
+        it('returns the converted event', async () => {
+          expect(await addEvent(event)).toEqual(event);
+        });
+      });
+
+      describe('when the insert fails', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns null', async () => {
+          expect(await addEvent(event)).toBeNull();
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // canDeleteEvent
+  // ---------------------------------------------------------------------------
+
+  describe('canDeleteEvent', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns false', async () => {
+        expect(await canDeleteEvent(event)).toBe(false);
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      it('returns true', async () => {
+        expect(await canDeleteEvent(event)).toBe(true);
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // deleteEvent
+  // ---------------------------------------------------------------------------
+
+  describe('deleteEvent', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('does not access the database', async () => {
+        await deleteEvent(event);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+        (executeQuery as Mock).mockResolvedValue(null);
+      });
+
+      it('calls executeQuery', async () => {
+        await deleteEvent(event);
+        expect(executeQuery).toHaveBeenCalledOnce();
+      });
+
+      it('deletes from the events table', async () => {
+        await deleteEvent(event);
+        expect(mockFrom).toHaveBeenCalledWith('events');
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // fetchEventTypes
+  // ---------------------------------------------------------------------------
+
+  describe('fetchEventTypes', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns an empty array', async () => {
+        expect(await fetchEventTypes()).toEqual([]);
+      });
+
+      it('does not access the database', async () => {
+        await fetchEventTypes();
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue([eventTypeDTO]);
+        });
+
+        it('calls executeQuery', async () => {
+          await fetchEventTypes();
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('queries the event_types table', async () => {
+          await fetchEventTypes();
+          expect(mockFrom).toHaveBeenCalledWith('event_types');
+        });
+
+        it('returns the event types', async () => {
+          expect(await fetchEventTypes()).toEqual([eventTypeDTO]);
+        });
+      });
+
+      describe('when no data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns an empty array', async () => {
+          expect(await fetchEventTypes()).toEqual([]);
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // updateEvent
+  // ---------------------------------------------------------------------------
+
+  describe('updateEvent', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns null', async () => {
+        expect(await updateEvent(event)).toBeNull();
+      });
+
+      it('does not access the database', async () => {
+        await updateEvent(event);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when the update succeeds', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(eventDTO);
+        });
+
+        it('calls executeQuery', async () => {
+          await updateEvent(event);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('updates the events table', async () => {
+          await updateEvent(event);
+          expect(mockFrom).toHaveBeenCalledWith('events');
+        });
+
+        it('returns the converted event', async () => {
+          expect(await updateEvent(event)).toEqual(event);
+        });
+      });
+
+      describe('when the update fails', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns null', async () => {
+          expect(await updateEvent(event)).toBeNull();
+        });
+      });
+    });
+  });
+});

--- a/app/adventure/events/create/__tests__/actions.spec.ts
+++ b/app/adventure/events/create/__tests__/actions.spec.ts
@@ -1,0 +1,73 @@
+import { Event, Place } from '@/models';
+import { EVENTS } from '@/app/adventure/events/__mocks__/data';
+import { describe, beforeEach, vi, it, expect } from 'vitest';
+import type { Mock } from 'vitest';
+import { createConfirmed } from '../actions';
+import { addEvent } from '@/app/adventure/events/data';
+import { addPlace, fetchPlaceTypes } from '@/app/adventure/places/data';
+import { PLACE_TYPES } from '@/app/adventure/places/__mocks__/data';
+import { redirect } from 'next/navigation';
+
+vi.mock('@/app/adventure/events/data');
+vi.mock('@/app/adventure/places/data');
+vi.mock('next/navigation');
+
+const event: Event = { ...EVENTS.find((e) => e.id === 1)!, id: undefined };
+const place: Place = {
+  name: `Edit Me for: ${event.name}`,
+  description: null,
+  type: PLACE_TYPES[0],
+  website: null,
+  phoneNumber: null,
+  address: {
+    line1: null,
+    line2: null,
+    city: null,
+    state: null,
+    postal: null,
+  },
+};
+
+describe('events: createConfirmed', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls addEvent with the specified event', async () => {
+    await createConfirmed(event);
+    expect(addEvent).toHaveBeenCalledExactlyOnceWith(event);
+    expect(addPlace).not.toHaveBeenCalled();
+    expect(fetchPlaceTypes).not.toHaveBeenCalled();
+  });
+
+  it('adds a placeholder place if a place on the event is a fake that needs to be created', async () => {
+    const eventWithoutPlace = { ...event, place: { ...event.place, id: -1 } };
+    (fetchPlaceTypes as Mock).mockResolvedValue(PLACE_TYPES);
+    (addPlace as Mock).mockResolvedValue({ ...place, id: 420 });
+
+    await createConfirmed(eventWithoutPlace);
+    expect(fetchPlaceTypes).toHaveBeenCalledExactlyOnceWith();
+    expect(addPlace).toHaveBeenCalledExactlyOnceWith(place);
+    expect(addEvent).toHaveBeenCalledExactlyOnceWith({ ...eventWithoutPlace, place: { ...place, id: 420 } });
+  });
+
+  describe('when addEvent succeeds', () => {
+    beforeEach(() => {
+      (addEvent as any).mockResolvedValue({ ...event, id: 73 });
+    });
+
+    it('redirects to the events list page', async () => {
+      await createConfirmed(event);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/events');
+    });
+  });
+
+  describe('when addEvent fails', () => {
+    beforeEach(() => {
+      (addEvent as any).mockResolvedValue(null);
+    });
+
+    it('redirects to /error', async () => {
+      await createConfirmed(event);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
+    });
+  });
+});

--- a/app/adventure/events/create/__tests__/actions.spec.ts
+++ b/app/adventure/events/create/__tests__/actions.spec.ts
@@ -1,12 +1,11 @@
-import { Event, Place } from '@/models';
 import { EVENTS } from '@/app/adventure/events/__mocks__/data';
-import { describe, beforeEach, vi, it, expect } from 'vitest';
-import type { Mock } from 'vitest';
-import { createConfirmed } from '../actions';
 import { addEvent } from '@/app/adventure/events/data';
-import { addPlace, fetchPlaceTypes } from '@/app/adventure/places/data';
 import { PLACE_TYPES } from '@/app/adventure/places/__mocks__/data';
+import { addPlace, fetchPlaceTypes } from '@/app/adventure/places/data';
+import { Event, Place } from '@/models';
 import { redirect } from 'next/navigation';
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { createConfirmed } from '../actions';
 
 vi.mock('@/app/adventure/events/data');
 vi.mock('@/app/adventure/places/data');
@@ -51,7 +50,7 @@ describe('events: createConfirmed', () => {
 
   describe('when addEvent succeeds', () => {
     beforeEach(() => {
-      (addEvent as any).mockResolvedValue({ ...event, id: 73 });
+      (addEvent as Mock).mockResolvedValue({ ...event, id: 73 });
     });
 
     it('redirects to the events list page', async () => {
@@ -62,7 +61,7 @@ describe('events: createConfirmed', () => {
 
   describe('when addEvent fails', () => {
     beforeEach(() => {
-      (addEvent as any).mockResolvedValue(null);
+      (addEvent as Mock).mockResolvedValue(null);
     });
 
     it('redirects to /error', async () => {

--- a/app/adventure/notes/__tests__/data.spec.ts
+++ b/app/adventure/notes/__tests__/data.spec.ts
@@ -1,0 +1,287 @@
+import { executeQuery } from '@/utils/data';
+import { isNotLoggedIn } from '@/utils/supabase/auth';
+import { createClient } from '@/utils/supabase/server';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { addNote, canDeleteNote, deleteNote, fetchNote, updateNote } from '../data';
+
+vi.mock('@/utils/supabase/auth');
+vi.mock('@/utils/supabase/server');
+vi.mock('@/utils/data', () => ({ executeQuery: vi.fn() }));
+
+// --- Test data ---
+
+const noteDTO = {
+  id: 1,
+  name: 'Parking info',
+  description: 'Park in Lot 17, free after 5pm.',
+  equipment_rid: null,
+  event_rid: 4,
+  place_rid: null,
+};
+
+const note = {
+  id: 1,
+  name: 'Parking info',
+  description: 'Park in Lot 17, free after 5pm.',
+  equipmentRid: null,
+  eventRid: 4,
+  placeRid: null,
+};
+
+// --- Helpers ---
+
+const buildChainableMock = () => {
+  const chain: Record<string, Mock> = {};
+  ['select', 'insert', 'update', 'delete', 'eq', 'single'].forEach((method) => {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  });
+  return chain;
+};
+
+// --- Tests ---
+
+describe('notes data', () => {
+  let mockFrom: Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const chain = buildChainableMock();
+    mockFrom = vi.fn().mockReturnValue(chain);
+    vi.mocked(createClient).mockReturnValue({ from: mockFrom } as any);
+  });
+
+  // ---------------------------------------------------------------------------
+  // fetchNote
+  // ---------------------------------------------------------------------------
+
+  describe('fetchNote', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns null', async () => {
+        expect(await fetchNote(1)).toBeNull();
+      });
+
+      it('does not access the database', async () => {
+        await fetchNote(1);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(noteDTO);
+        });
+
+        it('calls executeQuery', async () => {
+          await fetchNote(1);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('queries the notes table', async () => {
+          await fetchNote(1);
+          expect(mockFrom).toHaveBeenCalledWith('notes');
+        });
+
+        it('returns the converted note', async () => {
+          expect(await fetchNote(1)).toEqual(note);
+        });
+      });
+
+      describe('when no data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns null', async () => {
+          expect(await fetchNote(1)).toBeNull();
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // addNote
+  // ---------------------------------------------------------------------------
+
+  describe('addNote', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns null', async () => {
+        expect(await addNote(note)).toBeNull();
+      });
+
+      it('does not access the database', async () => {
+        await addNote(note);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when the insert succeeds', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(noteDTO);
+        });
+
+        it('calls executeQuery', async () => {
+          await addNote(note);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('inserts into the notes table', async () => {
+          await addNote(note);
+          expect(mockFrom).toHaveBeenCalledWith('notes');
+        });
+
+        it('returns the converted note', async () => {
+          expect(await addNote(note)).toEqual(note);
+        });
+      });
+
+      describe('when the insert fails', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns null', async () => {
+          expect(await addNote(note)).toBeNull();
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // canDeleteNote
+  // ---------------------------------------------------------------------------
+
+  describe('canDeleteNote', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns false', async () => {
+        expect(await canDeleteNote(note)).toBe(false);
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      it('returns true', async () => {
+        expect(await canDeleteNote(note)).toBe(true);
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // deleteNote
+  // ---------------------------------------------------------------------------
+
+  describe('deleteNote', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('does not access the database', async () => {
+        await deleteNote(note);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+        (executeQuery as Mock).mockResolvedValue(null);
+      });
+
+      it('calls executeQuery', async () => {
+        await deleteNote(note);
+        expect(executeQuery).toHaveBeenCalledOnce();
+      });
+
+      it('deletes from the notes table', async () => {
+        await deleteNote(note);
+        expect(mockFrom).toHaveBeenCalledWith('notes');
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // updateNote
+  // ---------------------------------------------------------------------------
+
+  describe('updateNote', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns null', async () => {
+        expect(await updateNote(note)).toBeNull();
+      });
+
+      it('does not access the database', async () => {
+        await updateNote(note);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when the update succeeds', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(noteDTO);
+        });
+
+        it('calls executeQuery', async () => {
+          await updateNote(note);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('updates the notes table', async () => {
+          await updateNote(note);
+          expect(mockFrom).toHaveBeenCalledWith('notes');
+        });
+
+        it('returns the converted note', async () => {
+          expect(await updateNote(note)).toEqual(note);
+        });
+      });
+
+      describe('when the update fails', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns null', async () => {
+          expect(await updateNote(note)).toBeNull();
+        });
+      });
+    });
+  });
+});

--- a/app/adventure/notes/__tests__/data.spec.ts
+++ b/app/adventure/notes/__tests__/data.spec.ts
@@ -47,6 +47,7 @@ describe('notes data', () => {
     vi.clearAllMocks();
     const chain = buildChainableMock();
     mockFrom = vi.fn().mockReturnValue(chain);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vi.mocked(createClient).mockReturnValue({ from: mockFrom } as any);
   });
 

--- a/app/adventure/places/[id]/delete/__tests__/actions.spec.ts
+++ b/app/adventure/places/[id]/delete/__tests__/actions.spec.ts
@@ -1,0 +1,39 @@
+import { Place } from '@/models';
+import { PLACES } from '@/app/adventure/places/__mocks__/data';
+import { redirect } from 'next/navigation';
+import { describe, beforeEach, vi, it, expect } from 'vitest';
+import { deleteConfirmed, deleteAborted } from '../actions';
+import { deletePlace } from '@/app/adventure/places/data';
+
+vi.mock('@/app/adventure/places/data');
+vi.mock('next/navigation');
+
+const place: Place = PLACES.find((p) => p.id === 2)!;
+
+describe('places: delete actions', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe('deleteConfirmed', () => {
+    it('calls deletePlace', async () => {
+      await deleteConfirmed(place);
+      expect(deletePlace).toHaveBeenCalledExactlyOnceWith(place);
+    });
+
+    it('redirects to the places list page', async () => {
+      await deleteConfirmed(place);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/places');
+    });
+  });
+
+  describe('deleteAborted', () => {
+    it('does not call deletePlace', async () => {
+      await deleteAborted();
+      expect(deletePlace).not.toHaveBeenCalled();
+    });
+
+    it('redirects to the places list page', async () => {
+      await deleteAborted();
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/places');
+    });
+  });
+});

--- a/app/adventure/places/[id]/notes/[noteId]/delete/__tests__/actions.spec.ts
+++ b/app/adventure/places/[id]/notes/[noteId]/delete/__tests__/actions.spec.ts
@@ -1,0 +1,39 @@
+import { NOTES } from '@/app/adventure/notes/__mocks__/data';
+import { Note } from '@/models';
+import { redirect } from 'next/navigation';
+import { describe, beforeEach, vi, it, expect } from 'vitest';
+import { deleteConfirmed, deleteAborted } from '../actions';
+import { deleteNote } from '@/app/adventure/notes/data';
+
+vi.mock('@/app/adventure/notes/data');
+vi.mock('next/navigation');
+
+const note: Note = { ...NOTES.find((n) => n.placeRid !== null)!, placeRid: 314 };
+
+describe('place notes: delete actions', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe('deleteConfirmed', () => {
+    it('calls deleteNote', async () => {
+      await deleteConfirmed(19, note);
+      expect(deleteNote).toHaveBeenCalledExactlyOnceWith(note);
+    });
+
+    it('redirects to the place details page', async () => {
+      await deleteConfirmed(19, note);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/places/19');
+    });
+  });
+
+  describe('deleteAborted', () => {
+    it('does not call deleteNote', async () => {
+      await deleteAborted(19);
+      expect(deleteNote).not.toHaveBeenCalled();
+    });
+
+    it('redirects to the place details page', async () => {
+      await deleteAborted(19);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/places/19');
+    });
+  });
+});

--- a/app/adventure/places/[id]/notes/[noteId]/update/__tests__/actions.spec.ts
+++ b/app/adventure/places/[id]/notes/[noteId]/update/__tests__/actions.spec.ts
@@ -1,0 +1,42 @@
+import { NOTES } from '@/app/adventure/notes/__mocks__/data';
+import { updateNote } from '@/app/adventure/notes/data';
+import { Note } from '@/models';
+import { redirect } from 'next/navigation';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { updateConfirmed } from '../actions';
+
+vi.mock('@/app/adventure/notes/data');
+vi.mock('next/navigation');
+
+const note: Note = { ...NOTES.find((n) => n.placeRid !== null)!, placeRid: 14 };
+
+describe('place notes: updateConfirmed', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls updateNote with the specified note', async () => {
+    await updateConfirmed(note);
+    expect(updateNote).toHaveBeenCalledExactlyOnceWith(note);
+  });
+
+  describe('when updateNote succeeds', () => {
+    beforeEach(() => {
+      (updateNote as any).mockResolvedValue(note);
+    });
+
+    it('redirects to the place details page', async () => {
+      await updateConfirmed(note);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/places/14');
+    });
+  });
+
+  describe('when updateNote fails', () => {
+    beforeEach(() => {
+      (updateNote as any).mockResolvedValue(null);
+    });
+
+    it('redirects to /error', async () => {
+      await updateConfirmed(note);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
+    });
+  });
+});

--- a/app/adventure/places/[id]/notes/[noteId]/update/__tests__/actions.spec.ts
+++ b/app/adventure/places/[id]/notes/[noteId]/update/__tests__/actions.spec.ts
@@ -2,7 +2,7 @@ import { NOTES } from '@/app/adventure/notes/__mocks__/data';
 import { updateNote } from '@/app/adventure/notes/data';
 import { Note } from '@/models';
 import { redirect } from 'next/navigation';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import { updateConfirmed } from '../actions';
 
 vi.mock('@/app/adventure/notes/data');
@@ -20,7 +20,7 @@ describe('place notes: updateConfirmed', () => {
 
   describe('when updateNote succeeds', () => {
     beforeEach(() => {
-      (updateNote as any).mockResolvedValue(note);
+      (updateNote as Mock).mockResolvedValue(note);
     });
 
     it('redirects to the place details page', async () => {
@@ -31,7 +31,7 @@ describe('place notes: updateConfirmed', () => {
 
   describe('when updateNote fails', () => {
     beforeEach(() => {
-      (updateNote as any).mockResolvedValue(null);
+      (updateNote as Mock).mockResolvedValue(null);
     });
 
     it('redirects to /error', async () => {

--- a/app/adventure/places/[id]/notes/create/__tests__/actions.spec.ts
+++ b/app/adventure/places/[id]/notes/create/__tests__/actions.spec.ts
@@ -1,0 +1,42 @@
+import { NOTES } from '@/app/adventure/notes/__mocks__/data';
+import { Note } from '@/models';
+import { describe, beforeEach, vi, it, expect } from 'vitest';
+import { createConfirmed } from '../actions';
+import { addNote } from '@/app/adventure/notes/data';
+import { redirect } from 'next/navigation';
+
+vi.mock('@/app/adventure/notes/data');
+vi.mock('next/navigation');
+
+const note: Note = { ...NOTES.find((n) => n.placeRid !== null)!, id: undefined, placeRid: 19 };
+
+describe('place notes: createConfirmed', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls addNote with the specified note', async () => {
+    await createConfirmed(note);
+    expect(addNote).toHaveBeenCalledExactlyOnceWith(note);
+  });
+
+  describe('when addNote succeeds', () => {
+    beforeEach(() => {
+      (addNote as any).mockResolvedValue({ ...note, id: 73 });
+    });
+
+    it('redirects to the place details page', async () => {
+      await createConfirmed(note);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/places/19');
+    });
+  });
+
+  describe('when addNote fails', () => {
+    beforeEach(() => {
+      (addNote as any).mockResolvedValue(null);
+    });
+
+    it('redirects to /error', async () => {
+      await createConfirmed(note);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
+    });
+  });
+});

--- a/app/adventure/places/[id]/notes/create/__tests__/actions.spec.ts
+++ b/app/adventure/places/[id]/notes/create/__tests__/actions.spec.ts
@@ -1,6 +1,6 @@
 import { NOTES } from '@/app/adventure/notes/__mocks__/data';
 import { Note } from '@/models';
-import { describe, beforeEach, vi, it, expect } from 'vitest';
+import { describe, beforeEach, vi, it, expect, type Mock } from 'vitest';
 import { createConfirmed } from '../actions';
 import { addNote } from '@/app/adventure/notes/data';
 import { redirect } from 'next/navigation';
@@ -20,7 +20,7 @@ describe('place notes: createConfirmed', () => {
 
   describe('when addNote succeeds', () => {
     beforeEach(() => {
-      (addNote as any).mockResolvedValue({ ...note, id: 73 });
+      (addNote as Mock).mockResolvedValue({ ...note, id: 73 });
     });
 
     it('redirects to the place details page', async () => {
@@ -31,7 +31,7 @@ describe('place notes: createConfirmed', () => {
 
   describe('when addNote fails', () => {
     beforeEach(() => {
-      (addNote as any).mockResolvedValue(null);
+      (addNote as Mock).mockResolvedValue(null);
     });
 
     it('redirects to /error', async () => {

--- a/app/adventure/places/[id]/update/__tests__/actions.spec.ts
+++ b/app/adventure/places/[id]/update/__tests__/actions.spec.ts
@@ -1,0 +1,42 @@
+import { PLACES } from '@/app/adventure/places/__mocks__/data';
+import { updatePlace } from '@/app/adventure/places/data';
+import { Place } from '@/models';
+import { redirect } from 'next/navigation';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { updateConfirmed } from '../actions';
+
+vi.mock('@/app/adventure/places/data');
+vi.mock('next/navigation');
+
+const place: Place = PLACES.find((p) => p.id === 2)!;
+
+describe('places: updateConfirmed', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls updatePlace with the specified place', async () => {
+    await updateConfirmed(place);
+    expect(updatePlace).toHaveBeenCalledExactlyOnceWith(place);
+  });
+
+  describe('when the update succeeds', () => {
+    beforeEach(() => {
+      (updatePlace as any).mockResolvedValue(place);
+    });
+
+    it('redirects to the places list page', async () => {
+      await updateConfirmed(place);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/places');
+    });
+  });
+
+  describe('when the update fails', () => {
+    beforeEach(() => {
+      (updatePlace as any).mockResolvedValue(null);
+    });
+
+    it('redirects to /error', async () => {
+      await updateConfirmed(place);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
+    });
+  });
+});

--- a/app/adventure/places/[id]/update/__tests__/actions.spec.ts
+++ b/app/adventure/places/[id]/update/__tests__/actions.spec.ts
@@ -2,7 +2,7 @@ import { PLACES } from '@/app/adventure/places/__mocks__/data';
 import { updatePlace } from '@/app/adventure/places/data';
 import { Place } from '@/models';
 import { redirect } from 'next/navigation';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import { updateConfirmed } from '../actions';
 
 vi.mock('@/app/adventure/places/data');
@@ -20,7 +20,7 @@ describe('places: updateConfirmed', () => {
 
   describe('when the update succeeds', () => {
     beforeEach(() => {
-      (updatePlace as any).mockResolvedValue(place);
+      (updatePlace as Mock).mockResolvedValue(place);
     });
 
     it('redirects to the places list page', async () => {
@@ -31,7 +31,7 @@ describe('places: updateConfirmed', () => {
 
   describe('when the update fails', () => {
     beforeEach(() => {
-      (updatePlace as any).mockResolvedValue(null);
+      (updatePlace as Mock).mockResolvedValue(null);
     });
 
     it('redirects to /error', async () => {

--- a/app/adventure/places/__mocks__/data.ts
+++ b/app/adventure/places/__mocks__/data.ts
@@ -1,7 +1,7 @@
 import { Place, PlaceType } from '@/models';
 import { vi } from 'vitest';
 
-const PLACE_TYPES: Array<PlaceType> = [
+export const PLACE_TYPES: Array<PlaceType> = [
   {
     id: 1,
     name: 'State Park',

--- a/app/adventure/places/__tests__/data.spec.ts
+++ b/app/adventure/places/__tests__/data.spec.ts
@@ -1,0 +1,484 @@
+import { executeQuery } from '@/utils/data';
+import { isNotLoggedIn } from '@/utils/supabase/auth';
+import { createClient } from '@/utils/supabase/server';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { addPlace, canDeletePlace, deletePlace, fetchPlace, fetchPlaces, fetchPlaceTypes, updatePlace } from '../data';
+
+vi.mock('@/utils/supabase/auth');
+vi.mock('@/utils/supabase/server');
+vi.mock('@/utils/data', () => ({ executeQuery: vi.fn() }));
+
+// --- Test data ---
+
+const placeTypeDTO = { id: 3, name: 'Campground', description: 'A place to camp' };
+
+const placeDTO = {
+  id: 1,
+  name: 'Test Campground',
+  description: 'A test campground',
+  address_line_1: '123 Main St',
+  address_line_2: null,
+  city: 'Anytown',
+  state: 'CA',
+  postal_code: '12345',
+  phone_number: '555-555-5555',
+  website: 'https://example.com',
+  place_type_rid: 3,
+  place_types: placeTypeDTO,
+};
+
+const placeWithNotesDTO = {
+  ...placeDTO,
+  notes: [
+    {
+      id: 8,
+      name: 'Bring firewood',
+      description: 'Check local restrictions',
+      place_rid: 1,
+      equipment_rid: null,
+      event_rid: null,
+    },
+  ],
+};
+
+const place = {
+  id: 1,
+  name: 'Test Campground',
+  description: 'A test campground',
+  address: {
+    line1: '123 Main St',
+    line2: null,
+    city: 'Anytown',
+    state: 'CA',
+    postal: '12345',
+  },
+  phoneNumber: '555-555-5555',
+  website: 'https://example.com',
+  type: { id: 3, name: 'Campground', description: 'A place to camp' },
+};
+
+const placeWithNotes = {
+  ...place,
+  notes: [
+    {
+      id: 8,
+      name: 'Bring firewood',
+      description: 'Check local restrictions',
+      placeRid: 1,
+      equipmentRid: null,
+      eventRid: null,
+    },
+  ],
+};
+
+// --- Helpers ---
+
+const buildChainableMock = () => {
+  const chain: Record<string, Mock> = {};
+  ['select', 'insert', 'update', 'delete', 'eq', 'single', 'order'].forEach((method) => {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  });
+  return chain;
+};
+
+// --- Tests ---
+
+describe('places data', () => {
+  let mockFrom: Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const chain = buildChainableMock();
+    mockFrom = vi.fn().mockReturnValue(chain);
+    vi.mocked(createClient).mockReturnValue({ from: mockFrom } as any);
+  });
+
+  // ---------------------------------------------------------------------------
+  // fetchPlaces
+  // ---------------------------------------------------------------------------
+
+  describe('fetchPlaces', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns an empty array', async () => {
+        expect(await fetchPlaces()).toEqual([]);
+      });
+
+      it('does not access the database', async () => {
+        await fetchPlaces();
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue([placeDTO]);
+        });
+
+        it('calls executeQuery', async () => {
+          await fetchPlaces();
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('queries the places table', async () => {
+          await fetchPlaces();
+          expect(mockFrom).toHaveBeenCalledWith('places');
+        });
+
+        it('returns the converted places list', async () => {
+          expect(await fetchPlaces()).toEqual([place]);
+        });
+      });
+
+      describe('when no data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns an empty array', async () => {
+          expect(await fetchPlaces()).toEqual([]);
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // fetchPlace
+  // ---------------------------------------------------------------------------
+
+  describe.each([true, false])('fetchPlace full: $0', (full: boolean) => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns null', async () => {
+        expect(await fetchPlace(1, full)).toBeNull();
+      });
+
+      it('does not access the database', async () => {
+        await fetchPlace(1, full);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(full ? placeWithNotesDTO : placeDTO);
+        });
+
+        it('calls executeQuery', async () => {
+          await fetchPlace(1, full);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('queries the places table', async () => {
+          await fetchPlace(1, full);
+          expect(mockFrom).toHaveBeenCalledWith('places');
+        });
+
+        it('returns the converted place', async () => {
+          expect(await fetchPlace(1, full)).toEqual(full ? placeWithNotes : place);
+        });
+      });
+
+      describe('when no data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns null', async () => {
+          expect(await fetchPlace(1, full)).toBeNull();
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // addPlace
+  // ---------------------------------------------------------------------------
+
+  describe('addPlace', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns null', async () => {
+        expect(await addPlace(place as any)).toBeNull();
+      });
+
+      it('does not access the database', async () => {
+        await addPlace(place as any);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when the insert succeeds', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(placeDTO);
+        });
+
+        it('calls executeQuery', async () => {
+          await addPlace(place as any);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('inserts into the places table', async () => {
+          await addPlace(place as any);
+          expect(mockFrom).toHaveBeenCalledWith('places');
+        });
+
+        it('returns the converted place', async () => {
+          expect(await addPlace(place as any)).toEqual(place);
+        });
+      });
+
+      describe('when the insert fails', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns null', async () => {
+          expect(await addPlace(place as any)).toBeNull();
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // fetchPlaceTypes
+  // ---------------------------------------------------------------------------
+
+  describe('fetchPlaceTypes', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns an empty array', async () => {
+        expect(await fetchPlaceTypes()).toEqual([]);
+      });
+
+      it('does not access the database', async () => {
+        await fetchPlaceTypes();
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue([placeTypeDTO]);
+        });
+
+        it('calls executeQuery', async () => {
+          await fetchPlaceTypes();
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('queries the place_types table', async () => {
+          await fetchPlaceTypes();
+          expect(mockFrom).toHaveBeenCalledWith('place_types');
+        });
+
+        it('returns the place types', async () => {
+          expect(await fetchPlaceTypes()).toEqual([{ id: 3, name: 'Campground', description: 'A place to camp' }]);
+        });
+      });
+
+      describe('when no data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns an empty array', async () => {
+          expect(await fetchPlaceTypes()).toEqual([]);
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // canDeletePlace
+  // ---------------------------------------------------------------------------
+
+  describe('canDeletePlace', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns false', async () => {
+        expect(await canDeletePlace(place as any)).toBe(false);
+      });
+
+      it('does not access the database', async () => {
+        await canDeletePlace(place as any);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      it('queries the events table', async () => {
+        (executeQuery as Mock).mockResolvedValue({ count: 0 });
+        await canDeletePlace(place as any);
+        expect(mockFrom).toHaveBeenCalledWith('events');
+      });
+
+      describe('when the place is not used in any events', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue({ count: 0 });
+        });
+
+        it('returns true', async () => {
+          expect(await canDeletePlace(place as any)).toBe(true);
+        });
+      });
+
+      describe('when the place is used in one or more events', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue({ count: 3 });
+        });
+
+        it('returns false', async () => {
+          expect(await canDeletePlace(place as any)).toBe(false);
+        });
+      });
+
+      describe('when the query returns no data', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns false', async () => {
+          expect(await canDeletePlace(place as any)).toBe(false);
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // deletePlace
+  // ---------------------------------------------------------------------------
+
+  describe('deletePlace', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('does not access the database', async () => {
+        await deletePlace(place as any);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+        (executeQuery as Mock).mockResolvedValue(null);
+      });
+
+      it('calls executeQuery', async () => {
+        await deletePlace(place as any);
+        expect(executeQuery).toHaveBeenCalledOnce();
+      });
+
+      it('deletes from the places table', async () => {
+        await deletePlace(place as any);
+        expect(mockFrom).toHaveBeenCalledWith('places');
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // updatePlace
+  // ---------------------------------------------------------------------------
+
+  describe('updatePlace', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns null', async () => {
+        expect(await updatePlace(place as any)).toBeNull();
+      });
+
+      it('does not access the database', async () => {
+        await updatePlace(place as any);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when the update succeeds', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(placeDTO);
+        });
+
+        it('calls executeQuery', async () => {
+          await updatePlace(place as any);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('updates the places table', async () => {
+          await updatePlace(place as any);
+          expect(mockFrom).toHaveBeenCalledWith('places');
+        });
+
+        it('returns the converted place', async () => {
+          expect(await updatePlace(place as any)).toEqual(place);
+        });
+      });
+
+      describe('when the update fails', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns null', async () => {
+          expect(await updatePlace(place as any)).toBeNull();
+        });
+      });
+    });
+  });
+});

--- a/app/adventure/places/__tests__/data.spec.ts
+++ b/app/adventure/places/__tests__/data.spec.ts
@@ -90,6 +90,7 @@ describe('places data', () => {
     vi.clearAllMocks();
     const chain = buildChainableMock();
     mockFrom = vi.fn().mockReturnValue(chain);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vi.mocked(createClient).mockReturnValue({ from: mockFrom } as any);
   });
 
@@ -220,11 +221,11 @@ describe('places data', () => {
       });
 
       it('returns null', async () => {
-        expect(await addPlace(place as any)).toBeNull();
+        expect(await addPlace(place)).toBeNull();
       });
 
       it('does not access the database', async () => {
-        await addPlace(place as any);
+        await addPlace(place);
         expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
@@ -241,17 +242,17 @@ describe('places data', () => {
         });
 
         it('calls executeQuery', async () => {
-          await addPlace(place as any);
+          await addPlace(place);
           expect(executeQuery).toHaveBeenCalledOnce();
         });
 
         it('inserts into the places table', async () => {
-          await addPlace(place as any);
+          await addPlace(place);
           expect(mockFrom).toHaveBeenCalledWith('places');
         });
 
         it('returns the converted place', async () => {
-          expect(await addPlace(place as any)).toEqual(place);
+          expect(await addPlace(place)).toEqual(place);
         });
       });
 
@@ -261,7 +262,7 @@ describe('places data', () => {
         });
 
         it('returns null', async () => {
-          expect(await addPlace(place as any)).toBeNull();
+          expect(await addPlace(place)).toBeNull();
         });
       });
     });
@@ -336,11 +337,11 @@ describe('places data', () => {
       });
 
       it('returns false', async () => {
-        expect(await canDeletePlace(place as any)).toBe(false);
+        expect(await canDeletePlace(place)).toBe(false);
       });
 
       it('does not access the database', async () => {
-        await canDeletePlace(place as any);
+        await canDeletePlace(place);
         expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
@@ -353,7 +354,7 @@ describe('places data', () => {
 
       it('queries the events table', async () => {
         (executeQuery as Mock).mockResolvedValue({ count: 0 });
-        await canDeletePlace(place as any);
+        await canDeletePlace(place);
         expect(mockFrom).toHaveBeenCalledWith('events');
       });
 
@@ -363,7 +364,7 @@ describe('places data', () => {
         });
 
         it('returns true', async () => {
-          expect(await canDeletePlace(place as any)).toBe(true);
+          expect(await canDeletePlace(place)).toBe(true);
         });
       });
 
@@ -373,7 +374,7 @@ describe('places data', () => {
         });
 
         it('returns false', async () => {
-          expect(await canDeletePlace(place as any)).toBe(false);
+          expect(await canDeletePlace(place)).toBe(false);
         });
       });
 
@@ -383,7 +384,7 @@ describe('places data', () => {
         });
 
         it('returns false', async () => {
-          expect(await canDeletePlace(place as any)).toBe(false);
+          expect(await canDeletePlace(place)).toBe(false);
         });
       });
     });
@@ -400,7 +401,7 @@ describe('places data', () => {
       });
 
       it('does not access the database', async () => {
-        await deletePlace(place as any);
+        await deletePlace(place);
         expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
@@ -413,12 +414,12 @@ describe('places data', () => {
       });
 
       it('calls executeQuery', async () => {
-        await deletePlace(place as any);
+        await deletePlace(place);
         expect(executeQuery).toHaveBeenCalledOnce();
       });
 
       it('deletes from the places table', async () => {
-        await deletePlace(place as any);
+        await deletePlace(place);
         expect(mockFrom).toHaveBeenCalledWith('places');
       });
     });
@@ -435,11 +436,11 @@ describe('places data', () => {
       });
 
       it('returns null', async () => {
-        expect(await updatePlace(place as any)).toBeNull();
+        expect(await updatePlace(place)).toBeNull();
       });
 
       it('does not access the database', async () => {
-        await updatePlace(place as any);
+        await updatePlace(place);
         expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
@@ -456,17 +457,17 @@ describe('places data', () => {
         });
 
         it('calls executeQuery', async () => {
-          await updatePlace(place as any);
+          await updatePlace(place);
           expect(executeQuery).toHaveBeenCalledOnce();
         });
 
         it('updates the places table', async () => {
-          await updatePlace(place as any);
+          await updatePlace(place);
           expect(mockFrom).toHaveBeenCalledWith('places');
         });
 
         it('returns the converted place', async () => {
-          expect(await updatePlace(place as any)).toEqual(place);
+          expect(await updatePlace(place)).toEqual(place);
         });
       });
 
@@ -476,7 +477,7 @@ describe('places data', () => {
         });
 
         it('returns null', async () => {
-          expect(await updatePlace(place as any)).toBeNull();
+          expect(await updatePlace(place)).toBeNull();
         });
       });
     });

--- a/app/adventure/places/create/__tests__/actions.spec.ts
+++ b/app/adventure/places/create/__tests__/actions.spec.ts
@@ -1,0 +1,42 @@
+import { Place } from '@/models';
+import { PLACES } from '@/app/adventure/places/__mocks__/data';
+import { createConfirmed } from '../actions';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { addPlace } from '@/app/adventure/places/data';
+import { redirect } from 'next/navigation';
+
+vi.mock('@/app/adventure/places/data');
+vi.mock('next/navigation');
+
+const place: Place = { ...PLACES.find((p) => p.id === 2)!, id: undefined };
+
+describe('places: createConfirmed', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls addPlace with the specified place', async () => {
+    await createConfirmed(place);
+    expect(addPlace).toHaveBeenCalledExactlyOnceWith(place);
+  });
+
+  describe('on success', () => {
+    beforeEach(() => {
+      (addPlace as any).mockResolvedValue({ ...place, id: 73 });
+    });
+
+    it('redirects to the places page', async () => {
+      await createConfirmed(place);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/places');
+    });
+  });
+
+  describe('on failure', () => {
+    beforeEach(() => {
+      (addPlace as any).mockResolvedValue(null);
+    });
+
+    it('redirects to the error page', async () => {
+      await createConfirmed(place);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
+    });
+  });
+});

--- a/app/adventure/places/create/__tests__/actions.spec.ts
+++ b/app/adventure/places/create/__tests__/actions.spec.ts
@@ -1,9 +1,9 @@
-import { Place } from '@/models';
 import { PLACES } from '@/app/adventure/places/__mocks__/data';
-import { createConfirmed } from '../actions';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { addPlace } from '@/app/adventure/places/data';
+import { Place } from '@/models';
 import { redirect } from 'next/navigation';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { createConfirmed } from '../actions';
 
 vi.mock('@/app/adventure/places/data');
 vi.mock('next/navigation');
@@ -20,7 +20,7 @@ describe('places: createConfirmed', () => {
 
   describe('on success', () => {
     beforeEach(() => {
-      (addPlace as any).mockResolvedValue({ ...place, id: 73 });
+      (addPlace as Mock).mockResolvedValue({ ...place, id: 73 });
     });
 
     it('redirects to the places page', async () => {
@@ -31,7 +31,7 @@ describe('places: createConfirmed', () => {
 
   describe('on failure', () => {
     beforeEach(() => {
-      (addPlace as any).mockResolvedValue(null);
+      (addPlace as Mock).mockResolvedValue(null);
     });
 
     it('redirects to the error page', async () => {

--- a/app/adventure/todos/[id]/delete/__tests__/actions.spec.ts
+++ b/app/adventure/todos/[id]/delete/__tests__/actions.spec.ts
@@ -1,0 +1,57 @@
+import { TODO_COLLECTIONS } from '@/app/adventure/todos/__mocks__/data';
+import { deleteTodoCollection } from '@/app/adventure/todos/data';
+import { TodoCollection } from '@/models';
+import { redirect } from 'next/navigation';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { deleteAborted, deleteConfirmed } from '../actions';
+
+vi.mock('@/app/adventure/todos/data');
+vi.mock('next/navigation');
+
+const todoCollection: TodoCollection = TODO_COLLECTIONS.find((c) => c.id === 1)!;
+
+describe('todos: delete actions', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe.each([
+    {
+      page: 'Home',
+      path: '/adventure',
+    },
+    {
+      page: 'Default',
+      path: '/adventure/todos',
+    },
+  ])('deleteConfirmed for $page', ({ page, path }) => {
+    it('calls deleteTodoCollection', async () => {
+      await deleteConfirmed(todoCollection, page).catch(() => {});
+      expect(deleteTodoCollection).toHaveBeenCalledExactlyOnceWith(todoCollection);
+    });
+
+    it('redirects to /adventure/todos', async () => {
+      await deleteConfirmed(todoCollection, page).catch(() => {});
+      expect(redirect).toHaveBeenCalledExactlyOnceWith(path);
+    });
+  });
+
+  describe.each([
+    {
+      page: 'Home',
+      path: '/adventure',
+    },
+    {
+      page: 'Default',
+      path: '/adventure/todos',
+    },
+  ])('deleteAborted for $page', ({ page, path }) => {
+    it('does not call deleteTodoCollection', async () => {
+      await deleteAborted(page).catch(() => {});
+      expect(deleteTodoCollection).not.toHaveBeenCalled();
+    });
+
+    it('redirects to /adventure/todos', async () => {
+      await deleteAborted(page).catch(() => {});
+      expect(redirect).toHaveBeenCalledExactlyOnceWith(path);
+    });
+  });
+});

--- a/app/adventure/todos/[id]/update/__tests__/actions.spec.ts
+++ b/app/adventure/todos/[id]/update/__tests__/actions.spec.ts
@@ -1,0 +1,51 @@
+import { TodoCollection } from '@/models';
+import { redirect } from 'next/navigation';
+import { describe, beforeEach, vi, it, expect } from 'vitest';
+import { TODO_COLLECTIONS } from '@/app/adventure/todos/__mocks__/data';
+import { updateConfirmed } from '../actions';
+import { updateTodoCollection } from '@/app/adventure/todos/data';
+
+vi.mock('@/app/adventure/todos/data');
+vi.mock('next/navigation');
+
+const todoCollection: TodoCollection = TODO_COLLECTIONS.find((c) => c.id === 1)!;
+
+describe.each([
+  {
+    page: 'Home',
+    path: '/adventure',
+  },
+  {
+    page: 'Default',
+    path: '/adventure/todos',
+  },
+])('todos: updateConfirmed for $page', ({ page, path }) => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls updateTodoCollection with the specified collection', async () => {
+    await updateConfirmed(todoCollection, page);
+    expect(updateTodoCollection).toHaveBeenCalledExactlyOnceWith(todoCollection);
+  });
+
+  describe('when the update succeeds', () => {
+    beforeEach(() => {
+      (updateTodoCollection as any).mockResolvedValue(todoCollection);
+    });
+
+    it('redirects to the todos list page', async () => {
+      await updateConfirmed(todoCollection, page);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith(path);
+    });
+  });
+
+  describe('when the update fails', () => {
+    beforeEach(() => {
+      (updateTodoCollection as any).mockResolvedValue(null);
+    });
+
+    it('redirects to /error', async () => {
+      await updateConfirmed(todoCollection, page);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
+    });
+  });
+});

--- a/app/adventure/todos/[id]/update/__tests__/actions.spec.ts
+++ b/app/adventure/todos/[id]/update/__tests__/actions.spec.ts
@@ -1,9 +1,9 @@
+import { TODO_COLLECTIONS } from '@/app/adventure/todos/__mocks__/data';
+import { updateTodoCollection } from '@/app/adventure/todos/data';
 import { TodoCollection } from '@/models';
 import { redirect } from 'next/navigation';
-import { describe, beforeEach, vi, it, expect } from 'vitest';
-import { TODO_COLLECTIONS } from '@/app/adventure/todos/__mocks__/data';
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 import { updateConfirmed } from '../actions';
-import { updateTodoCollection } from '@/app/adventure/todos/data';
 
 vi.mock('@/app/adventure/todos/data');
 vi.mock('next/navigation');
@@ -29,7 +29,7 @@ describe.each([
 
   describe('when the update succeeds', () => {
     beforeEach(() => {
-      (updateTodoCollection as any).mockResolvedValue(todoCollection);
+      (updateTodoCollection as Mock).mockResolvedValue(todoCollection);
     });
 
     it('redirects to the todos list page', async () => {
@@ -40,7 +40,7 @@ describe.each([
 
   describe('when the update fails', () => {
     beforeEach(() => {
-      (updateTodoCollection as any).mockResolvedValue(null);
+      (updateTodoCollection as Mock).mockResolvedValue(null);
     });
 
     it('redirects to /error', async () => {

--- a/app/adventure/todos/__tests__/data.spec.ts
+++ b/app/adventure/todos/__tests__/data.spec.ts
@@ -89,6 +89,7 @@ describe('todos data', () => {
     vi.clearAllMocks();
     const chain = buildChainableMock();
     mockFrom = vi.fn().mockReturnValue(chain);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vi.mocked(createClient).mockReturnValue({ from: mockFrom } as any);
   });
 

--- a/app/adventure/todos/__tests__/data.spec.ts
+++ b/app/adventure/todos/__tests__/data.spec.ts
@@ -1,0 +1,632 @@
+import { executeQuery } from '@/utils/data';
+import { isNotLoggedIn } from '@/utils/supabase/auth';
+import { createClient } from '@/utils/supabase/server';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import {
+  addTodoCollection,
+  addTodoItem,
+  canDeleteTodoCollection,
+  canDeleteTodoItem,
+  deleteTodoCollection,
+  deleteTodoItem,
+  fetchDueTodoCollections,
+  fetchTodoCollection,
+  fetchTodoCollections,
+  updateTodoCollection,
+  updateTodoItem,
+} from '../data';
+
+vi.mock('@/utils/supabase/auth');
+vi.mock('@/utils/supabase/server');
+vi.mock('@/utils/data', () => ({ executeQuery: vi.fn() }));
+
+// --- Test data ---
+
+const todoItemDTO = {
+  id: 5,
+  name: 'Tent',
+  is_complete: false,
+  todo_collection_rid: 1,
+};
+
+const todoItem = {
+  id: 5,
+  name: 'Tent',
+  isComplete: false,
+  todoCollectionRid: 1,
+};
+
+const todoCollectionDTO = {
+  id: 1,
+  name: 'Pack for camping',
+  description: 'Things to bring',
+  due_date: '2025-07-01',
+  is_complete: false,
+  event_rid: null,
+  equipment_rid: null,
+  todo_items: [],
+};
+
+const todoCollection = {
+  id: 1,
+  name: 'Pack for camping',
+  description: 'Things to bring',
+  dueDate: '2025-07-01',
+  isComplete: false,
+  eventRid: null,
+  event: undefined,
+  equipmentRid: null,
+  equipment: undefined,
+  todoItems: [],
+};
+
+const todoCollectionDTOWithItems = {
+  ...todoCollectionDTO,
+  todo_items: [todoItemDTO],
+};
+
+const todoCollectionWithItems = {
+  ...todoCollection,
+  todoItems: [todoItem],
+};
+
+// --- Helpers ---
+
+const buildChainableMock = () => {
+  const chain: Record<string, Mock> = {};
+  ['select', 'insert', 'update', 'delete', 'eq', 'single', 'order', 'lt'].forEach((method) => {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  });
+  return chain;
+};
+
+// --- Tests ---
+
+describe('todos data', () => {
+  let mockFrom: Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const chain = buildChainableMock();
+    mockFrom = vi.fn().mockReturnValue(chain);
+    vi.mocked(createClient).mockReturnValue({ from: mockFrom } as any);
+  });
+
+  // ---------------------------------------------------------------------------
+  // fetchTodoCollections
+  // ---------------------------------------------------------------------------
+
+  describe('fetchTodoCollections', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns an empty array', async () => {
+        expect(await fetchTodoCollections()).toEqual([]);
+      });
+
+      it('does not access the database', async () => {
+        await fetchTodoCollections();
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue([todoCollectionDTO]);
+        });
+
+        it('calls executeQuery', async () => {
+          await fetchTodoCollections();
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('queries the todo_collections table', async () => {
+          await fetchTodoCollections();
+          expect(mockFrom).toHaveBeenCalledWith('todo_collections');
+        });
+
+        it('returns the converted todo collections', async () => {
+          expect(await fetchTodoCollections()).toEqual([todoCollection]);
+        });
+
+        it('converts nested todo items', async () => {
+          (executeQuery as Mock).mockResolvedValueOnce([todoCollectionDTOWithItems]);
+          expect(await fetchTodoCollections()).toEqual([todoCollectionWithItems]);
+        });
+      });
+
+      describe('when no data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns an empty array', async () => {
+          expect(await fetchTodoCollections()).toEqual([]);
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // fetchTodoCollection
+  // ---------------------------------------------------------------------------
+
+  describe('fetchTodoCollection', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns null', async () => {
+        expect(await fetchTodoCollection(1)).toBeNull();
+      });
+
+      it('does not access the database', async () => {
+        await fetchTodoCollection(1);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(todoCollectionDTO);
+        });
+
+        it('calls executeQuery', async () => {
+          await fetchTodoCollection(1);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('queries the todo_collections table', async () => {
+          await fetchTodoCollection(1);
+          expect(mockFrom).toHaveBeenCalledWith('todo_collections');
+        });
+
+        it('returns the converted todo collection', async () => {
+          expect(await fetchTodoCollection(1)).toEqual(todoCollection);
+        });
+
+        it('converts nested todo items', async () => {
+          (executeQuery as Mock).mockResolvedValueOnce(todoCollectionDTOWithItems);
+          expect(await fetchTodoCollection(1)).toEqual(todoCollectionWithItems);
+        });
+      });
+
+      describe('when no data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns null', async () => {
+          expect(await fetchTodoCollection(1)).toBeNull();
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // fetchDueTodoCollections
+  // ---------------------------------------------------------------------------
+
+  describe('fetchDueTodoCollections', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns an empty array', async () => {
+        expect(await fetchDueTodoCollections('2025-07-01')).toEqual([]);
+      });
+
+      it('does not access the database', async () => {
+        await fetchDueTodoCollections('2025-07-01');
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue([todoCollectionDTO]);
+        });
+
+        it('calls executeQuery', async () => {
+          await fetchDueTodoCollections('2025-07-01');
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('queries the todo_collections table', async () => {
+          await fetchDueTodoCollections('2025-07-01');
+          expect(mockFrom).toHaveBeenCalledWith('todo_collections');
+        });
+
+        it('returns the converted todo collections', async () => {
+          expect(await fetchDueTodoCollections('2025-07-01')).toEqual([todoCollection]);
+        });
+      });
+
+      describe('when no data is returned', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns an empty array', async () => {
+          expect(await fetchDueTodoCollections('2025-07-01')).toEqual([]);
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // addTodoCollection
+  // ---------------------------------------------------------------------------
+
+  describe('addTodoCollection', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns null', async () => {
+        expect(await addTodoCollection(todoCollection)).toBeNull();
+      });
+
+      it('does not access the database', async () => {
+        await addTodoCollection(todoCollection);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when the insert succeeds', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(todoCollectionDTO);
+        });
+
+        it('calls executeQuery', async () => {
+          await addTodoCollection(todoCollection);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('inserts into the todo_collections table', async () => {
+          await addTodoCollection(todoCollection);
+          expect(mockFrom).toHaveBeenCalledWith('todo_collections');
+        });
+
+        it('returns the converted todo collection', async () => {
+          expect(await addTodoCollection(todoCollection)).toEqual(todoCollection);
+        });
+      });
+
+      describe('when the insert fails', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns null', async () => {
+          expect(await addTodoCollection(todoCollection)).toBeNull();
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // canDeleteTodoCollection
+  // ---------------------------------------------------------------------------
+
+  describe('canDeleteTodoCollection', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns false', async () => {
+        expect(await canDeleteTodoCollection(todoCollection)).toBe(false);
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      it('returns true', async () => {
+        expect(await canDeleteTodoCollection(todoCollection)).toBe(true);
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // deleteTodoCollection
+  // ---------------------------------------------------------------------------
+
+  describe('deleteTodoCollection', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('does not access the database', async () => {
+        await deleteTodoCollection(todoCollection);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+        (executeQuery as Mock).mockResolvedValue(null);
+      });
+
+      it('calls executeQuery', async () => {
+        await deleteTodoCollection(todoCollection);
+        expect(executeQuery).toHaveBeenCalledOnce();
+      });
+
+      it('deletes from the todo_collections table', async () => {
+        await deleteTodoCollection(todoCollection);
+        expect(mockFrom).toHaveBeenCalledWith('todo_collections');
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // updateTodoCollection
+  // ---------------------------------------------------------------------------
+
+  describe('updateTodoCollection', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns null', async () => {
+        expect(await updateTodoCollection(todoCollection)).toBeNull();
+      });
+
+      it('does not access the database', async () => {
+        await updateTodoCollection(todoCollection);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when the update succeeds', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(todoCollectionDTO);
+        });
+
+        it('calls executeQuery', async () => {
+          await updateTodoCollection(todoCollection);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('updates the todo_collections table', async () => {
+          await updateTodoCollection(todoCollection);
+          expect(mockFrom).toHaveBeenCalledWith('todo_collections');
+        });
+
+        it('returns the converted todo collection', async () => {
+          expect(await updateTodoCollection(todoCollection)).toEqual(todoCollection);
+        });
+      });
+
+      describe('when the update fails', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns null', async () => {
+          expect(await updateTodoCollection(todoCollection)).toBeNull();
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // addTodoItem
+  // ---------------------------------------------------------------------------
+
+  describe('addTodoItem', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns null', async () => {
+        expect(await addTodoItem(todoItem)).toBeNull();
+      });
+
+      it('does not access the database', async () => {
+        await addTodoItem(todoItem);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when the insert succeeds', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(todoItemDTO);
+        });
+
+        it('calls executeQuery', async () => {
+          await addTodoItem(todoItem);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('inserts into the todo_items table', async () => {
+          await addTodoItem(todoItem);
+          expect(mockFrom).toHaveBeenCalledWith('todo_items');
+        });
+
+        it('returns the converted todo item', async () => {
+          expect(await addTodoItem(todoItem)).toEqual(todoItem);
+        });
+      });
+
+      describe('when the insert fails', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns null', async () => {
+          expect(await addTodoItem(todoItem)).toBeNull();
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // canDeleteTodoItem
+  // ---------------------------------------------------------------------------
+
+  describe('canDeleteTodoItem', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns false', async () => {
+        expect(await canDeleteTodoItem(todoItem)).toBe(false);
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      it('returns true', async () => {
+        expect(await canDeleteTodoItem(todoItem)).toBe(true);
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // deleteTodoItem
+  // ---------------------------------------------------------------------------
+
+  describe('deleteTodoItem', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('does not access the database', async () => {
+        await deleteTodoItem(todoItem);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+        (executeQuery as Mock).mockResolvedValue(null);
+      });
+
+      it('calls executeQuery', async () => {
+        await deleteTodoItem(todoItem);
+        expect(executeQuery).toHaveBeenCalledOnce();
+      });
+
+      it('deletes from the todo_items table', async () => {
+        await deleteTodoItem(todoItem);
+        expect(mockFrom).toHaveBeenCalledWith('todo_items');
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // updateTodoItem
+  // ---------------------------------------------------------------------------
+
+  describe('updateTodoItem', () => {
+    describe('when not logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(true);
+      });
+
+      it('returns null', async () => {
+        expect(await updateTodoItem(todoItem)).toBeNull();
+      });
+
+      it('does not access the database', async () => {
+        await updateTodoItem(todoItem);
+        expect(createClient).not.toHaveBeenCalled();
+        expect(executeQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when logged in', () => {
+      beforeEach(() => {
+        (isNotLoggedIn as Mock).mockResolvedValue(false);
+      });
+
+      describe('when the update succeeds', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(todoItemDTO);
+        });
+
+        it('calls executeQuery', async () => {
+          await updateTodoItem(todoItem);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('updates the todo_items table', async () => {
+          await updateTodoItem(todoItem);
+          expect(mockFrom).toHaveBeenCalledWith('todo_items');
+        });
+
+        it('returns the converted todo item', async () => {
+          expect(await updateTodoItem(todoItem)).toEqual(todoItem);
+        });
+      });
+
+      describe('when the update fails', () => {
+        beforeEach(() => {
+          (executeQuery as Mock).mockResolvedValue(null);
+        });
+
+        it('returns null', async () => {
+          expect(await updateTodoItem(todoItem)).toBeNull();
+        });
+      });
+    });
+  });
+});

--- a/app/adventure/todos/create/__tests__/actions.spec.ts
+++ b/app/adventure/todos/create/__tests__/actions.spec.ts
@@ -1,0 +1,42 @@
+import { TodoCollection } from '@/models';
+import { TODO_COLLECTIONS } from '@/app/adventure/todos/__mocks__/data';
+import { redirect } from 'next/navigation';
+import { describe, beforeEach, vi, it, expect } from 'vitest';
+import { createConfirmed } from '../actions';
+import { addTodoCollection } from '@/app/adventure/todos/data';
+
+vi.mock('@/app/adventure/todos/data');
+vi.mock('next/navigation');
+
+const todoCollection: TodoCollection = { ...TODO_COLLECTIONS.find((c) => c.id === 1)!, id: undefined };
+
+describe('todo collection: createConfirmed', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls addTodoCollection with the specified collection', async () => {
+    await createConfirmed(todoCollection);
+    expect(addTodoCollection).toHaveBeenCalledExactlyOnceWith(todoCollection);
+  });
+
+  describe('when addTodoCollection succeeds', () => {
+    beforeEach(() => {
+      (addTodoCollection as any).mockResolvedValue({ ...todoCollection, id: 73 });
+    });
+
+    it('redirects to the todo collections list page', async () => {
+      await createConfirmed(todoCollection);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/todos');
+    });
+  });
+
+  describe('when addTodoCollection fails', () => {
+    beforeEach(() => {
+      (addTodoCollection as any).mockResolvedValue(null);
+    });
+
+    it('redirects to /error', async () => {
+      await createConfirmed(todoCollection);
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
+    });
+  });
+});

--- a/app/adventure/todos/create/__tests__/actions.spec.ts
+++ b/app/adventure/todos/create/__tests__/actions.spec.ts
@@ -1,9 +1,9 @@
-import { TodoCollection } from '@/models';
 import { TODO_COLLECTIONS } from '@/app/adventure/todos/__mocks__/data';
-import { redirect } from 'next/navigation';
-import { describe, beforeEach, vi, it, expect } from 'vitest';
-import { createConfirmed } from '../actions';
 import { addTodoCollection } from '@/app/adventure/todos/data';
+import { TodoCollection } from '@/models';
+import { redirect } from 'next/navigation';
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { createConfirmed } from '../actions';
 
 vi.mock('@/app/adventure/todos/data');
 vi.mock('next/navigation');
@@ -20,7 +20,7 @@ describe('todo collection: createConfirmed', () => {
 
   describe('when addTodoCollection succeeds', () => {
     beforeEach(() => {
-      (addTodoCollection as any).mockResolvedValue({ ...todoCollection, id: 73 });
+      (addTodoCollection as Mock).mockResolvedValue({ ...todoCollection, id: 73 });
     });
 
     it('redirects to the todo collections list page', async () => {
@@ -31,7 +31,7 @@ describe('todo collection: createConfirmed', () => {
 
   describe('when addTodoCollection fails', () => {
     beforeEach(() => {
-      (addTodoCollection as any).mockResolvedValue(null);
+      (addTodoCollection as Mock).mockResolvedValue(null);
     });
 
     it('redirects to /error', async () => {


### PR DESCRIPTION
Introduce comprehensive unit tests for data layer functions and Next.js server actions across various application modules. Also, add an `.editorconfig` to enforce consistent code styling.

Relates to #16