### PR TITLE
Guard data access with `withAuth` HOF

### DIFF
--- a/.changeset/clean-balloons-wink.md
+++ b/.changeset/clean-balloons-wink.md
@@ -1,0 +1,5 @@
+---
+'recreation-planner': patch
+---
+
+Guard the database authorization by wrapping queries in a single higher order function.

--- a/app/adventure/equipment/__tests__/data.spec.ts
+++ b/app/adventure/equipment/__tests__/data.spec.ts
@@ -18,7 +18,6 @@ import {
   updateEquipment,
   updateMaintenanceItem,
 } from '../data';
-import { create } from 'node:domain';
 
 vi.mock('@/utils/supabase/server');
 vi.mock('@/utils/data', () => ({ executeQuery: vi.fn() }));

--- a/app/adventure/equipment/__tests__/data.spec.ts
+++ b/app/adventure/equipment/__tests__/data.spec.ts
@@ -1,5 +1,5 @@
+import { buildChainableMock, setLoggedIn, setLoggedOut } from '@/test-utils/data-helpers';
 import { executeQuery } from '@/utils/data';
-import { isNotLoggedIn } from '@/utils/supabase/auth';
 import { createClient } from '@/utils/supabase/server';
 import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import {
@@ -18,8 +18,8 @@ import {
   updateEquipment,
   updateMaintenanceItem,
 } from '../data';
+import { create } from 'node:domain';
 
-vi.mock('@/utils/supabase/auth');
 vi.mock('@/utils/supabase/server');
 vi.mock('@/utils/data', () => ({ executeQuery: vi.fn() }));
 
@@ -99,16 +99,6 @@ const maintenanceItem = {
   equipmentRid: 1,
 };
 
-// --- Helpers ---
-
-const buildChainableMock = () => {
-  const chain: Record<string, Mock> = {};
-  ['select', 'insert', 'update', 'delete', 'eq', 'single', 'order'].forEach((method) => {
-    chain[method] = vi.fn().mockReturnValue(chain);
-  });
-  return chain;
-};
-
 // --- Tests ---
 
 describe('equipment data', () => {
@@ -118,8 +108,10 @@ describe('equipment data', () => {
     vi.clearAllMocks();
     const chain = buildChainableMock();
     mockFrom = vi.fn().mockReturnValue(chain);
+    const client = createClient();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    vi.mocked(createClient).mockReturnValue({ from: mockFrom } as any);
+    vi.mocked(createClient).mockReturnValue({ ...client, from: mockFrom } as any);
+    vi.clearAllMocks();
   });
 
   // ---------------------------------------------------------------------------
@@ -128,9 +120,7 @@ describe('equipment data', () => {
 
   describe('fetchAllEquipment', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('returns an empty array', async () => {
         expect(await fetchAllEquipment()).toEqual([]);
@@ -138,15 +128,12 @@ describe('equipment data', () => {
 
       it('does not access the database', async () => {
         await fetchAllEquipment();
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(() => setLoggedIn());
 
       describe('when data is returned', () => {
         beforeEach(() => {
@@ -186,9 +173,7 @@ describe('equipment data', () => {
 
   describe('fetchEquipment', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('returns null', async () => {
         expect(await fetchEquipment(1)).toBeNull();
@@ -196,15 +181,12 @@ describe('equipment data', () => {
 
       it('does not access the database', async () => {
         await fetchEquipment(1);
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(() => setLoggedIn());
 
       describe('when data is returned', () => {
         beforeEach(() => {
@@ -244,9 +226,7 @@ describe('equipment data', () => {
 
   describe('addEquipment', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('returns null', async () => {
         expect(await addEquipment(equipment)).toBeNull();
@@ -254,15 +234,12 @@ describe('equipment data', () => {
 
       it('does not access the database', async () => {
         await addEquipment(equipment);
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(() => setLoggedIn());
 
       describe('when the insert succeeds', () => {
         beforeEach(() => {
@@ -302,9 +279,7 @@ describe('equipment data', () => {
 
   describe('canDeleteEquipment', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('returns false', async () => {
         expect(await canDeleteEquipment(equipment)).toBe(false);
@@ -312,9 +287,7 @@ describe('equipment data', () => {
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(() => setLoggedIn());
 
       it('returns true', async () => {
         expect(await canDeleteEquipment(equipment)).toBe(true);
@@ -328,20 +301,17 @@ describe('equipment data', () => {
 
   describe('deleteEquipment', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('does not access the database', async () => {
         await deleteEquipment(equipment);
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
       beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
+        setLoggedIn();
         (executeQuery as Mock).mockResolvedValue(null);
       });
 
@@ -363,9 +333,7 @@ describe('equipment data', () => {
 
   describe('updateEquipment', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('returns null', async () => {
         expect(await updateEquipment(equipment)).toBeNull();
@@ -373,15 +341,12 @@ describe('equipment data', () => {
 
       it('does not access the database', async () => {
         await updateEquipment(equipment);
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(() => setLoggedIn());
 
       describe('when the update succeeds', () => {
         beforeEach(() => {
@@ -421,9 +386,7 @@ describe('equipment data', () => {
 
   describe('fetchEquipmentTypes', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('returns an empty array', async () => {
         expect(await fetchEquipmentTypes()).toEqual([]);
@@ -431,15 +394,12 @@ describe('equipment data', () => {
 
       it('does not access the database', async () => {
         await fetchEquipmentTypes();
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(() => setLoggedIn());
 
       describe('when data is returned', () => {
         beforeEach(() => {
@@ -479,9 +439,7 @@ describe('equipment data', () => {
 
   describe('fetchMaintenanceItem', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('returns null', async () => {
         expect(await fetchMaintenanceItem(5)).toBeNull();
@@ -489,15 +447,12 @@ describe('equipment data', () => {
 
       it('does not access the database', async () => {
         await fetchMaintenanceItem(5);
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(() => setLoggedIn());
 
       describe('when data is returned', () => {
         beforeEach(() => {
@@ -537,9 +492,7 @@ describe('equipment data', () => {
 
   describe('addMaintenanceItem', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('returns null', async () => {
         expect(await addMaintenanceItem(maintenanceItem)).toBeNull();
@@ -547,15 +500,12 @@ describe('equipment data', () => {
 
       it('does not access the database', async () => {
         await addMaintenanceItem(maintenanceItem);
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(() => setLoggedIn());
 
       describe('when the insert succeeds', () => {
         beforeEach(() => {
@@ -595,9 +545,7 @@ describe('equipment data', () => {
 
   describe('canDeleteMaintenanceItem', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('returns false', async () => {
         expect(await canDeleteMaintenanceItem(maintenanceItem)).toBe(false);
@@ -605,9 +553,7 @@ describe('equipment data', () => {
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(() => setLoggedIn());
 
       it('returns true', async () => {
         expect(await canDeleteMaintenanceItem(maintenanceItem)).toBe(true);
@@ -621,20 +567,17 @@ describe('equipment data', () => {
 
   describe('deleteMaintenanceItem', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('does not access the database', async () => {
         await deleteMaintenanceItem(maintenanceItem);
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
       beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
+        setLoggedIn();
         (executeQuery as Mock).mockResolvedValue(null);
       });
 
@@ -656,9 +599,7 @@ describe('equipment data', () => {
 
   describe('updateMaintenanceItem', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('returns null', async () => {
         expect(await updateMaintenanceItem(maintenanceItem)).toBeNull();
@@ -666,15 +607,12 @@ describe('equipment data', () => {
 
       it('does not access the database', async () => {
         await updateMaintenanceItem(maintenanceItem);
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(() => setLoggedIn());
 
       describe('when the update succeeds', () => {
         beforeEach(() => {
@@ -714,9 +652,7 @@ describe('equipment data', () => {
 
   describe('fetchMaintenanceTypes', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('returns an empty array', async () => {
         expect(await fetchMaintenanceTypes()).toEqual([]);
@@ -724,15 +660,12 @@ describe('equipment data', () => {
 
       it('does not access the database', async () => {
         await fetchMaintenanceTypes();
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(() => setLoggedIn());
 
       describe('when data is returned', () => {
         beforeEach(() => {
@@ -774,9 +707,7 @@ describe('equipment data', () => {
 
   describe('fetchUsageUnits', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('returns an empty array', async () => {
         expect(await fetchUsageUnits()).toEqual([]);
@@ -784,15 +715,12 @@ describe('equipment data', () => {
 
       it('does not access the database', async () => {
         await fetchUsageUnits();
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(() => setLoggedIn());
 
       describe('when data is returned', () => {
         beforeEach(() => {

--- a/app/adventure/equipment/data.ts
+++ b/app/adventure/equipment/data.ts
@@ -4,10 +4,10 @@
 import {
   Equipment,
   EquipmentDTO,
-  MaintenanceItem,
-  MaintenanceItemDTO,
   EquipmentType,
   EquipmentTypeDTO,
+  MaintenanceItem,
+  MaintenanceItemDTO,
   MaintenanceType,
   MaintenanceTypeDTO,
   UsageUnits,
@@ -16,15 +16,14 @@ import {
 import {
   convertToEquipment,
   convertToEquipmentDTO,
+  convertToEquipmentType,
   convertToMaintenance,
   convertToMaintenanceDTO,
   convertToMaintenanceType,
-  convertToEquipmentType,
   convertToUsageUnits,
 } from '@/models/convert';
 import { executeQuery } from '@/utils/data';
-import { isNotLoggedIn } from '@/utils/supabase/auth';
-import { createClient } from '@/utils/supabase/server';
+import { withAuth } from '@/utils/supabase/auth';
 import { SupabaseClient } from '@supabase/supabase-js';
 
 const equipmentSelectColumns = '*, equipment_types!inner(*)';
@@ -95,147 +94,85 @@ const maintenanceItemUpdate = (supabase: SupabaseClient, item: MaintenanceItem):
     .single();
 
 export const fetchAllEquipment = async (): Promise<Equipment[]> => {
-  if (await isNotLoggedIn()) {
-    return [];
-  }
-
-  const supabase = createClient();
-  const query = equipmentQuery(supabase);
-  const data = await executeQuery<EquipmentDTO[]>(query);
+  const data = await withAuth((supabase: SupabaseClient) => executeQuery<EquipmentDTO[]>(equipmentQuery(supabase)));
   return (data || []).map((p) => convertToEquipment(p) as Equipment);
 };
 
 export const fetchEquipment = async (id: number, full?: boolean): Promise<Equipment | null> => {
-  if (await isNotLoggedIn()) {
-    return null;
-  }
-
-  const supabase = createClient();
-  const query = full ? fullEquipmentQuery(supabase, id) : equipmentQuery(supabase, id);
-  const data = await executeQuery<EquipmentDTO>(query);
+  const data = await withAuth((supabase: SupabaseClient) =>
+    executeQuery<EquipmentDTO>(full ? fullEquipmentQuery(supabase, id) : equipmentQuery(supabase, id)),
+  );
   return data ? (convertToEquipment(data) as Equipment) : null;
 };
 
 export const addEquipment = async (equipment: Equipment): Promise<Equipment | null> => {
-  if (await isNotLoggedIn()) {
-    return null;
-  }
-
-  const supabase = createClient();
-  const query = equipmentInsert(supabase, equipment);
-  const data = await executeQuery<EquipmentDTO>(query);
+  const data = await withAuth((supabase: SupabaseClient) =>
+    executeQuery<EquipmentDTO>(equipmentInsert(supabase, equipment)),
+  );
   return data ? (convertToEquipment(data) as Equipment) : null;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const canDeleteEquipment = async (equipment: Equipment): Promise<boolean> => {
-  if (await isNotLoggedIn()) {
-    return false;
-  }
-  return true;
+  return !!(await withAuth(async () => true));
 };
 
 export const deleteEquipment = async (equipment: Equipment): Promise<void> => {
-  if (await isNotLoggedIn()) {
-    return;
-  }
-
-  const supabase = createClient();
-  const query = equipmentDelete(supabase, equipment);
-  await executeQuery(query);
+  await withAuth((supabase: SupabaseClient) => executeQuery(equipmentDelete(supabase, equipment)));
 };
 
 export const updateEquipment = async (equipment: Equipment): Promise<Equipment | null> => {
-  if (await isNotLoggedIn()) {
-    return null;
-  }
-
-  const supabase = createClient();
-  const query = equipmentUpdate(supabase, equipment);
-  const data = await executeQuery<EquipmentDTO>(query);
+  const data = await withAuth((supabase: SupabaseClient) =>
+    executeQuery<EquipmentDTO>(equipmentUpdate(supabase, equipment)),
+  );
   return data ? (convertToEquipment(data) as Equipment) : null;
 };
 
 export const fetchEquipmentTypes = async (): Promise<EquipmentType[]> => {
-  if (await isNotLoggedIn()) {
-    return [];
-  }
-
-  const supabase = createClient();
-  const query = equipmentTypesQuery(supabase);
-  const data = await executeQuery<EquipmentTypeDTO[]>(query);
+  const data = await withAuth((supabase: SupabaseClient) =>
+    executeQuery<EquipmentTypeDTO[]>(equipmentTypesQuery(supabase)),
+  );
   return (data || []).map((p) => convertToEquipmentType(p) as EquipmentType);
 };
 
 export const fetchMaintenanceItem = async (id: number): Promise<MaintenanceItem | null> => {
-  if (await isNotLoggedIn()) {
-    return null;
-  }
-
-  const supabase = createClient();
-  const query = maintenanceItemQuery(supabase, id);
-  const data = await executeQuery<MaintenanceItemDTO>(query);
+  const data = await withAuth((supabase: SupabaseClient) =>
+    executeQuery<MaintenanceItemDTO>(maintenanceItemQuery(supabase, id)),
+  );
   return data && convertToMaintenance(data);
 };
 
 export const addMaintenanceItem = async (item: MaintenanceItem): Promise<MaintenanceItem | null> => {
-  if (await isNotLoggedIn()) {
-    return null;
-  }
-
-  const supabase = createClient();
-  const query = maintenanceItemInsert(supabase, item);
-  const data = await executeQuery<MaintenanceItemDTO>(query);
+  const data = await withAuth((supabase: SupabaseClient) =>
+    executeQuery<MaintenanceItemDTO>(maintenanceItemInsert(supabase, item)),
+  );
   return data ? convertToMaintenance(data) : null;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const canDeleteMaintenanceItem = async (item: MaintenanceItem): Promise<boolean> => {
-  if (await isNotLoggedIn()) {
-    return false;
-  }
-  return true;
+  return !!(await withAuth(async () => true));
 };
 
 export const deleteMaintenanceItem = async (item: MaintenanceItem): Promise<void> => {
-  if (await isNotLoggedIn()) {
-    return;
-  }
-
-  const supabase = createClient();
-  const query = maintenanceItemDelete(supabase, item);
-  await executeQuery(query);
+  await withAuth((supabase: SupabaseClient) => executeQuery(maintenanceItemDelete(supabase, item)));
 };
 
 export const updateMaintenanceItem = async (item: MaintenanceItem): Promise<MaintenanceItem | null> => {
-  if (await isNotLoggedIn()) {
-    return null;
-  }
-
-  const supabase = createClient();
-  const query = maintenanceItemUpdate(supabase, item);
-  const data = await executeQuery<MaintenanceItemDTO>(query);
+  const data = await withAuth((supabase: SupabaseClient) =>
+    executeQuery<MaintenanceItemDTO>(maintenanceItemUpdate(supabase, item)),
+  );
   return data ? convertToMaintenance(data) : null;
 };
 
 export const fetchMaintenanceTypes = async (): Promise<MaintenanceType[]> => {
-  if (await isNotLoggedIn()) {
-    return [];
-  }
-
-  const supabase = createClient();
-  const query = maintenanceTypesQuery(supabase);
-  const data = await executeQuery<MaintenanceTypeDTO[]>(query);
+  const data = await withAuth((supabase: SupabaseClient) =>
+    executeQuery<MaintenanceTypeDTO[]>(maintenanceTypesQuery(supabase)),
+  );
   return (data || []).map((p) => convertToMaintenanceType(p) as MaintenanceType);
 };
 
 export const fetchUsageUnits = async (): Promise<UsageUnits[]> => {
-  if (await isNotLoggedIn()) {
-    return [];
-  }
-
-  const supabase = createClient();
-  const query = usageUnitsQuery(supabase);
-  const data = await executeQuery<UsageUnitsDTO[]>(query);
+  const data = await withAuth((supabase: SupabaseClient) => executeQuery<UsageUnitsDTO[]>(usageUnitsQuery(supabase)));
   return (data || []).map((p) => convertToUsageUnits(p) as UsageUnits);
 };

--- a/app/adventure/events/[id]/itinerary/__tests__/data.spec.ts
+++ b/app/adventure/events/[id]/itinerary/__tests__/data.spec.ts
@@ -1,5 +1,4 @@
 import { executeQuery } from '@/utils/data';
-import { isNotLoggedIn } from '@/utils/supabase/auth';
 import { createClient } from '@/utils/supabase/server';
 import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import {
@@ -9,8 +8,8 @@ import {
   fetchItineraryItem,
   updateItineraryItem,
 } from '../data';
+import { buildChainableMock, setLoggedIn, setLoggedOut } from '@/test-utils/data-helpers';
 
-vi.mock('@/utils/supabase/auth');
 vi.mock('@/utils/supabase/server');
 vi.mock('@/utils/data', () => ({ executeQuery: vi.fn() }));
 
@@ -34,16 +33,6 @@ const itineraryItem = {
   eventRid: 14,
 };
 
-// --- Helpers ---
-
-const buildChainableMock = () => {
-  const chain: Record<string, Mock> = {};
-  ['select', 'insert', 'update', 'delete', 'eq', 'single'].forEach((method) => {
-    chain[method] = vi.fn().mockReturnValue(chain);
-  });
-  return chain;
-};
-
 // --- Tests ---
 
 describe('itinerary data', () => {
@@ -53,8 +42,10 @@ describe('itinerary data', () => {
     vi.clearAllMocks();
     const chain = buildChainableMock();
     mockFrom = vi.fn().mockReturnValue(chain);
+    const client = createClient();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    vi.mocked(createClient).mockReturnValue({ from: mockFrom } as any);
+    vi.mocked(createClient).mockReturnValue({ ...client, from: mockFrom } as any);
+    vi.clearAllMocks();
   });
 
   // ---------------------------------------------------------------------------
@@ -63,9 +54,7 @@ describe('itinerary data', () => {
 
   describe('fetchItineraryItem', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('returns null', async () => {
         expect(await fetchItineraryItem(1)).toBeNull();
@@ -73,15 +62,12 @@ describe('itinerary data', () => {
 
       it('does not access the database', async () => {
         await fetchItineraryItem(1);
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(() => setLoggedIn());
 
       describe('when data is returned', () => {
         beforeEach(() => {
@@ -121,9 +107,7 @@ describe('itinerary data', () => {
 
   describe('addItineraryItem', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('returns null', async () => {
         expect(await addItineraryItem(itineraryItem)).toBeNull();
@@ -131,15 +115,12 @@ describe('itinerary data', () => {
 
       it('does not access the database', async () => {
         await addItineraryItem(itineraryItem);
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(() => setLoggedIn());
 
       describe('when the insert succeeds', () => {
         beforeEach(() => {
@@ -179,9 +160,7 @@ describe('itinerary data', () => {
 
   describe('canDeleteItineraryItem', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('returns false', async () => {
         expect(await canDeleteItineraryItem(itineraryItem)).toBe(false);
@@ -189,9 +168,7 @@ describe('itinerary data', () => {
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(() => setLoggedIn());
 
       it('returns true', async () => {
         expect(await canDeleteItineraryItem(itineraryItem)).toBe(true);
@@ -205,20 +182,17 @@ describe('itinerary data', () => {
 
   describe('deleteItineraryItem', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('does not access the database', async () => {
         await deleteItineraryItem(itineraryItem);
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
       beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
+        setLoggedIn();
         (executeQuery as Mock).mockResolvedValue(null);
       });
 
@@ -240,9 +214,7 @@ describe('itinerary data', () => {
 
   describe('updateItineraryItem', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('returns null', async () => {
         expect(await updateItineraryItem(itineraryItem)).toBeNull();
@@ -250,15 +222,12 @@ describe('itinerary data', () => {
 
       it('does not access the database', async () => {
         await updateItineraryItem(itineraryItem);
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(() => setLoggedIn());
 
       describe('when the update succeeds', () => {
         beforeEach(() => {

--- a/app/adventure/events/[id]/itinerary/data.ts
+++ b/app/adventure/events/[id]/itinerary/data.ts
@@ -33,24 +33,16 @@ const itineraryItemDelete = (supabase: SupabaseClient, item: ItineraryItem): any
 };
 
 export const fetchItineraryItem = async (id: number): Promise<ItineraryItem | null> => {
-  if (await isNotLoggedIn()) {
-    return null;
-  }
-
-  const supabase = createClient();
-  const query = itineraryItemQuery(supabase, id);
-  const data = await executeQuery<ItineraryItemDTO>(query);
+  const data = await withAuth((supabase: SupabaseClient) =>
+    executeQuery<ItineraryItemDTO>(itineraryItemQuery(supabase, id)),
+  );
   return data ? convertToItineraryItem(data) : null;
 };
 
 export const addItineraryItem = async (item: ItineraryItem): Promise<ItineraryItem | null> => {
-  if (await isNotLoggedIn()) {
-    return null;
-  }
-
-  const supabase = createClient();
-  const query = itineraryItemInsert(supabase, item);
-  const data = await executeQuery<ItineraryItemDTO>(query);
+  const data = await withAuth((supabase: SupabaseClient) =>
+    executeQuery<ItineraryItemDTO>(itineraryItemInsert(supabase, item)),
+  );
   return data ? convertToItineraryItem(data) : null;
 };
 
@@ -60,22 +52,12 @@ export const canDeleteItineraryItem = async (item: ItineraryItem): Promise<boole
 };
 
 export const deleteItineraryItem = async (item: ItineraryItem): Promise<void> => {
-  if (await isNotLoggedIn()) {
-    return;
-  }
-
-  const supabase = createClient();
-  const query = itineraryItemDelete(supabase, item);
-  await executeQuery<void>(query);
+  await withAuth((supabase: SupabaseClient) => executeQuery<void>(itineraryItemDelete(supabase, item)));
 };
 
 export const updateItineraryItem = async (item: ItineraryItem): Promise<ItineraryItem | null> => {
-  if (await isNotLoggedIn()) {
-    return null;
-  }
-
-  const supabase = createClient();
-  const query = itineraryItemUpdate(supabase, item);
-  const data = await executeQuery<ItineraryItemDTO>(query);
+  const data = await withAuth((supabase: SupabaseClient) =>
+    executeQuery<ItineraryItemDTO>(itineraryItemUpdate(supabase, item)),
+  );
   return data ? convertToItineraryItem(data) : null;
 };

--- a/app/adventure/events/[id]/itinerary/data.ts
+++ b/app/adventure/events/[id]/itinerary/data.ts
@@ -4,8 +4,7 @@
 import { ItineraryItem, ItineraryItemDTO } from '@/models';
 import { convertToItineraryItem, convertToItineraryItemDTO } from '@/models/convert';
 import { executeQuery } from '@/utils/data';
-import { isNotLoggedIn, withAuth } from '@/utils/supabase/auth';
-import { createClient } from '@/utils/supabase/server';
+import { withAuth } from '@/utils/supabase/auth';
 import { SupabaseClient } from '@supabase/supabase-js';
 
 const selectColumns = '*';

--- a/app/adventure/events/[id]/itinerary/data.ts
+++ b/app/adventure/events/[id]/itinerary/data.ts
@@ -4,7 +4,7 @@
 import { ItineraryItem, ItineraryItemDTO } from '@/models';
 import { convertToItineraryItem, convertToItineraryItemDTO } from '@/models/convert';
 import { executeQuery } from '@/utils/data';
-import { isNotLoggedIn } from '@/utils/supabase/auth';
+import { isNotLoggedIn, withAuth } from '@/utils/supabase/auth';
 import { createClient } from '@/utils/supabase/server';
 import { SupabaseClient } from '@supabase/supabase-js';
 
@@ -56,10 +56,7 @@ export const addItineraryItem = async (item: ItineraryItem): Promise<ItineraryIt
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const canDeleteItineraryItem = async (item: ItineraryItem): Promise<boolean> => {
-  if (await isNotLoggedIn()) {
-    return false;
-  }
-  return true;
+  return !!(await withAuth(async () => true));
 };
 
 export const deleteItineraryItem = async (item: ItineraryItem): Promise<void> => {

--- a/app/adventure/events/__tests__/data.spec.ts
+++ b/app/adventure/events/__tests__/data.spec.ts
@@ -12,6 +12,7 @@ import {
   fetchUpcomingEvents,
   updateEvent,
 } from '../data';
+import { buildChainableMock, setLoggedIn, setLoggedOut } from '@/test-utils/data-helpers';
 
 vi.mock('@/utils/supabase/server');
 vi.mock('@/utils/data', () => ({ executeQuery: vi.fn() }));
@@ -82,28 +83,6 @@ const event = {
   itinerary: undefined,
   notes: undefined,
   todoCollections: undefined,
-};
-
-// --- Helpers ---
-
-const buildChainableMock = () => {
-  const chain: Record<string, Mock> = {};
-  ['select', 'insert', 'update', 'delete', 'eq', 'single', 'order', 'or', 'limit'].forEach((method) => {
-    chain[method] = vi.fn().mockReturnValue(chain);
-  });
-  return chain;
-};
-
-const setLoggedOut = () => {
-  const client = createClient();
-  (client.auth.getUser as Mock).mockResolvedValue({ data: { user: null }, error: null });
-  vi.clearAllMocks();
-};
-
-const setLoggedIn = () => {
-  const client = createClient();
-  (client.auth.getUser as Mock).mockResolvedValue({ data: { user: { id: 'foo', name: 'Bar Baz' } }, error: null });
-  vi.clearAllMocks();
 };
 
 // --- Tests ---

--- a/app/adventure/events/__tests__/data.spec.ts
+++ b/app/adventure/events/__tests__/data.spec.ts
@@ -1,5 +1,4 @@
 import { executeQuery } from '@/utils/data';
-import { isNotLoggedIn } from '@/utils/supabase/auth';
 import { createClient } from '@/utils/supabase/server';
 import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import {
@@ -14,7 +13,6 @@ import {
   updateEvent,
 } from '../data';
 
-vi.mock('@/utils/supabase/auth');
 vi.mock('@/utils/supabase/server');
 vi.mock('@/utils/data', () => ({ executeQuery: vi.fn() }));
 
@@ -96,6 +94,18 @@ const buildChainableMock = () => {
   return chain;
 };
 
+const setLoggedOut = () => {
+  const client = createClient();
+  (client.auth.getUser as Mock).mockResolvedValue({ data: { user: null }, error: null });
+  vi.clearAllMocks();
+};
+
+const setLoggedIn = () => {
+  const client = createClient();
+  (client.auth.getUser as Mock).mockResolvedValue({ data: { user: { id: 'foo', name: 'Bar Baz' } }, error: null });
+  vi.clearAllMocks();
+};
+
 // --- Tests ---
 
 describe('events data', () => {
@@ -105,8 +115,10 @@ describe('events data', () => {
     vi.clearAllMocks();
     const chain = buildChainableMock();
     mockFrom = vi.fn().mockReturnValue(chain);
+    const client = createClient();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    vi.mocked(createClient).mockReturnValue({ from: mockFrom } as any);
+    vi.mocked(createClient).mockReturnValue({ ...client, from: mockFrom } as any);
+    vi.clearAllMocks();
   });
 
   // ---------------------------------------------------------------------------
@@ -115,9 +127,7 @@ describe('events data', () => {
 
   describe('fetchUpcomingEvents', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(setLoggedOut);
 
       it('returns an empty array', async () => {
         expect(await fetchUpcomingEvents('2024-01-01')).toEqual([]);
@@ -125,15 +135,12 @@ describe('events data', () => {
 
       it('does not access the database', async () => {
         await fetchUpcomingEvents('2024-01-01');
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(setLoggedIn);
 
       describe('when data is returned', () => {
         beforeEach(() => {
@@ -178,9 +185,7 @@ describe('events data', () => {
 
   describe('fetchPriorEvents', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(setLoggedOut);
 
       it('returns an empty array', async () => {
         expect(await fetchPriorEvents('2024-01-01')).toEqual([]);
@@ -188,15 +193,12 @@ describe('events data', () => {
 
       it('does not access the database', async () => {
         await fetchPriorEvents('2024-01-01');
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(setLoggedIn);
 
       describe('when data is returned', () => {
         beforeEach(() => {
@@ -236,9 +238,7 @@ describe('events data', () => {
 
   describe('fetchLatestEvents', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(setLoggedOut);
 
       it('returns an empty array', async () => {
         expect(await fetchLatestEvents(5)).toEqual([]);
@@ -246,15 +246,12 @@ describe('events data', () => {
 
       it('does not access the database', async () => {
         await fetchLatestEvents(5);
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(setLoggedIn);
 
       describe('when data is returned', () => {
         beforeEach(() => {
@@ -294,9 +291,7 @@ describe('events data', () => {
 
   describe('fetchEvent', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(setLoggedOut);
 
       it('returns null', async () => {
         expect(await fetchEvent(1)).toBeNull();
@@ -304,15 +299,12 @@ describe('events data', () => {
 
       it('does not access the database', async () => {
         await fetchEvent(1);
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(setLoggedIn);
 
       describe('when data is returned', () => {
         beforeEach(() => {
@@ -363,9 +355,7 @@ describe('events data', () => {
 
   describe('addEvent', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(setLoggedOut);
 
       it('returns null', async () => {
         expect(await addEvent(event)).toBeNull();
@@ -373,15 +363,12 @@ describe('events data', () => {
 
       it('does not access the database', async () => {
         await addEvent(event);
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(setLoggedIn);
 
       describe('when the insert succeeds', () => {
         beforeEach(() => {
@@ -421,9 +408,7 @@ describe('events data', () => {
 
   describe('canDeleteEvent', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(setLoggedOut);
 
       it('returns false', async () => {
         expect(await canDeleteEvent(event)).toBe(false);
@@ -431,9 +416,7 @@ describe('events data', () => {
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(setLoggedIn);
 
       it('returns true', async () => {
         expect(await canDeleteEvent(event)).toBe(true);
@@ -447,22 +430,16 @@ describe('events data', () => {
 
   describe('deleteEvent', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(setLoggedOut);
 
       it('does not access the database', async () => {
         await deleteEvent(event);
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-        (executeQuery as Mock).mockResolvedValue(null);
-      });
+      beforeEach(setLoggedIn);
 
       it('calls executeQuery', async () => {
         await deleteEvent(event);
@@ -482,9 +459,7 @@ describe('events data', () => {
 
   describe('fetchEventTypes', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(setLoggedOut);
 
       it('returns an empty array', async () => {
         expect(await fetchEventTypes()).toEqual([]);
@@ -492,15 +467,12 @@ describe('events data', () => {
 
       it('does not access the database', async () => {
         await fetchEventTypes();
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(setLoggedIn);
 
       describe('when data is returned', () => {
         beforeEach(() => {
@@ -540,9 +512,7 @@ describe('events data', () => {
 
   describe('updateEvent', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(setLoggedOut);
 
       it('returns null', async () => {
         expect(await updateEvent(event)).toBeNull();
@@ -550,15 +520,12 @@ describe('events data', () => {
 
       it('does not access the database', async () => {
         await updateEvent(event);
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(setLoggedIn);
 
       describe('when the update succeeds', () => {
         beforeEach(() => {

--- a/app/adventure/events/data.ts
+++ b/app/adventure/events/data.ts
@@ -100,7 +100,7 @@ export const addEvent = async (event: Event): Promise<Event | null> => {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const canDeleteEvent = async (event: Event): Promise<boolean> => {
-  return !!(await withAuth(() => Promise.resolve(true)));
+  return !!(await withAuth(async () => true));
 };
 
 export const deleteEvent = async (event: Event): Promise<void> => {

--- a/app/adventure/events/data.ts
+++ b/app/adventure/events/data.ts
@@ -4,8 +4,7 @@
 import { Event, EventDTO, EventType } from '@/models';
 import { convertToEvent, convertToEventDTO } from '@/models/convert';
 import { executeQuery } from '@/utils/data';
-import { isNotLoggedIn, withAuth } from '@/utils/supabase/auth';
-import { createClient } from '@/utils/supabase/server';
+import { withAuth } from '@/utils/supabase/auth';
 import { SupabaseClient } from '@supabase/supabase-js';
 
 const selectColumns = '*, places!inner(*, place_types!inner(*)), event_types!inner(*)';
@@ -69,91 +68,51 @@ const eventTypesQuery = (supabase: SupabaseClient): any => {
 };
 
 export const fetchUpcomingEvents = async (startDate: string, endDate?: string): Promise<Event[]> => {
-  const data = await withAuth((supabase: SupabaseClient) => {
-    const query = upcomingEventsQuery(supabase, startDate, endDate);
-    return executeQuery<EventDTO[]>(query);
-  });
-
+  const data = await withAuth((supabase: SupabaseClient) =>
+    executeQuery<EventDTO[]>(upcomingEventsQuery(supabase, startDate, endDate)),
+  );
   return (data || []).map((p) => convertToEvent(p) as Event);
 };
 
 export const fetchPriorEvents = async (dt: string): Promise<Event[]> => {
-  const data = await withAuth((supabase: SupabaseClient) => {
-    const query = priorEventsQuery(supabase, dt);
-    return executeQuery<EventDTO[]>(query);
-  });
+  const data = await withAuth((supabase: SupabaseClient) => executeQuery<EventDTO[]>(priorEventsQuery(supabase, dt)));
   return (data || []).map((p) => convertToEvent(p) as Event);
 };
 
 export const fetchLatestEvents = async (count: number): Promise<Event[]> => {
-  if (await isNotLoggedIn()) {
-    return [];
-  }
-
-  const supabase = createClient();
-  const query = lastCreatedEventsQuery(supabase, count);
-  const data = await executeQuery<EventDTO[]>(query);
+  const data = await withAuth((supabase: SupabaseClient) =>
+    executeQuery<EventDTO[]>(lastCreatedEventsQuery(supabase, count)),
+  );
   return (data || []).map((p) => convertToEvent(p) as Event);
 };
 
 export const fetchEvent = async (id: number, full: boolean = false): Promise<Event | null> => {
-  if (await isNotLoggedIn()) {
-    return null;
-  }
-
-  const supabase = createClient();
-  const query = full ? fullEventQuery(supabase, id) : eventQuery(supabase, id);
-  const data = await executeQuery<EventDTO>(query);
+  const data = await withAuth((supabase: SupabaseClient) =>
+    executeQuery<EventDTO>(full ? fullEventQuery(supabase, id) : eventQuery(supabase, id)),
+  );
   return data ? (convertToEvent(data) as Event) : null;
 };
 
 export const addEvent = async (event: Event): Promise<Event | null> => {
-  if (await isNotLoggedIn()) {
-    return null;
-  }
-
-  const supabase = createClient();
-  const query = eventInsert(supabase, event);
-  const data = await executeQuery<EventDTO>(query);
+  const data = await withAuth((supabase: SupabaseClient) => executeQuery<EventDTO>(eventInsert(supabase, event)));
   return data ? (convertToEvent(data) as Event) : null;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const canDeleteEvent = async (event: Event): Promise<boolean> => {
-  if (await isNotLoggedIn()) {
-    return false;
-  }
-  return true;
+  return !!(await withAuth(() => Promise.resolve(true)));
 };
 
 export const deleteEvent = async (event: Event): Promise<void> => {
-  if (await isNotLoggedIn()) {
-    return;
-  }
-
-  const supabase = createClient();
-  const query = eventDelete(supabase, event);
-  await executeQuery<void>(query);
+  await withAuth((supabase: SupabaseClient) => executeQuery<void>(eventDelete(supabase, event)));
 };
 
 export const fetchEventTypes = async (): Promise<EventType[]> => {
-  if (await isNotLoggedIn()) {
-    return [];
-  }
-
-  const supabase = createClient();
-  const query = eventTypesQuery(supabase);
-  const data = await executeQuery<EventType[]>(query);
+  const data = await withAuth((supabase: SupabaseClient) => executeQuery<EventType[]>(eventTypesQuery(supabase)));
   return data || [];
 };
 
 export const updateEvent = async (event: Event): Promise<Event | null> => {
-  if (await isNotLoggedIn()) {
-    return null;
-  }
-
-  const supabase = createClient();
-  const query = eventUpdate(supabase, event);
-  const data = await executeQuery<EventDTO>(query);
+  const data = await withAuth((supabase: SupabaseClient) => executeQuery<EventDTO>(eventUpdate(supabase, event)));
   return data ? (convertToEvent(data) as Event) : null;
 };

--- a/app/adventure/events/data.ts
+++ b/app/adventure/events/data.ts
@@ -4,7 +4,7 @@
 import { Event, EventDTO, EventType } from '@/models';
 import { convertToEvent, convertToEventDTO } from '@/models/convert';
 import { executeQuery } from '@/utils/data';
-import { isNotLoggedIn } from '@/utils/supabase/auth';
+import { isNotLoggedIn, withAuth } from '@/utils/supabase/auth';
 import { createClient } from '@/utils/supabase/server';
 import { SupabaseClient } from '@supabase/supabase-js';
 
@@ -69,24 +69,19 @@ const eventTypesQuery = (supabase: SupabaseClient): any => {
 };
 
 export const fetchUpcomingEvents = async (startDate: string, endDate?: string): Promise<Event[]> => {
-  if (await isNotLoggedIn()) {
-    return [];
-  }
+  const data = await withAuth((supabase: SupabaseClient) => {
+    const query = upcomingEventsQuery(supabase, startDate, endDate);
+    return executeQuery<EventDTO[]>(query);
+  })();
 
-  const supabase = createClient();
-  const query = upcomingEventsQuery(supabase, startDate, endDate);
-  const data = await executeQuery<EventDTO[]>(query);
   return (data || []).map((p) => convertToEvent(p) as Event);
 };
 
 export const fetchPriorEvents = async (dt: string): Promise<Event[]> => {
-  if (await isNotLoggedIn()) {
-    return [];
-  }
-
-  const supabase = createClient();
-  const query = priorEventsQuery(supabase, dt);
-  const data = await executeQuery<EventDTO[]>(query);
+  const data = await withAuth((supabase: SupabaseClient) => {
+    const query = priorEventsQuery(supabase, dt);
+    return executeQuery<EventDTO[]>(query);
+  })();
   return (data || []).map((p) => convertToEvent(p) as Event);
 };
 

--- a/app/adventure/events/data.ts
+++ b/app/adventure/events/data.ts
@@ -72,7 +72,7 @@ export const fetchUpcomingEvents = async (startDate: string, endDate?: string): 
   const data = await withAuth((supabase: SupabaseClient) => {
     const query = upcomingEventsQuery(supabase, startDate, endDate);
     return executeQuery<EventDTO[]>(query);
-  })();
+  });
 
   return (data || []).map((p) => convertToEvent(p) as Event);
 };
@@ -81,7 +81,7 @@ export const fetchPriorEvents = async (dt: string): Promise<Event[]> => {
   const data = await withAuth((supabase: SupabaseClient) => {
     const query = priorEventsQuery(supabase, dt);
     return executeQuery<EventDTO[]>(query);
-  })();
+  });
   return (data || []).map((p) => convertToEvent(p) as Event);
 };
 

--- a/app/adventure/notes/__tests__/data.spec.ts
+++ b/app/adventure/notes/__tests__/data.spec.ts
@@ -1,10 +1,9 @@
+import { buildChainableMock, setLoggedIn, setLoggedOut } from '@/test-utils/data-helpers';
 import { executeQuery } from '@/utils/data';
-import { isNotLoggedIn } from '@/utils/supabase/auth';
 import { createClient } from '@/utils/supabase/server';
 import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import { addNote, canDeleteNote, deleteNote, fetchNote, updateNote } from '../data';
 
-vi.mock('@/utils/supabase/auth');
 vi.mock('@/utils/supabase/server');
 vi.mock('@/utils/data', () => ({ executeQuery: vi.fn() }));
 
@@ -28,16 +27,6 @@ const note = {
   placeRid: null,
 };
 
-// --- Helpers ---
-
-const buildChainableMock = () => {
-  const chain: Record<string, Mock> = {};
-  ['select', 'insert', 'update', 'delete', 'eq', 'single'].forEach((method) => {
-    chain[method] = vi.fn().mockReturnValue(chain);
-  });
-  return chain;
-};
-
 // --- Tests ---
 
 describe('notes data', () => {
@@ -48,7 +37,9 @@ describe('notes data', () => {
     const chain = buildChainableMock();
     mockFrom = vi.fn().mockReturnValue(chain);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    vi.mocked(createClient).mockReturnValue({ from: mockFrom } as any);
+    const client = createClient();
+    vi.mocked(createClient).mockReturnValue({ ...client, from: mockFrom } as any);
+    vi.clearAllMocks();
   });
 
   // ---------------------------------------------------------------------------
@@ -57,9 +48,7 @@ describe('notes data', () => {
 
   describe('fetchNote', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('returns null', async () => {
         expect(await fetchNote(1)).toBeNull();
@@ -67,15 +56,12 @@ describe('notes data', () => {
 
       it('does not access the database', async () => {
         await fetchNote(1);
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(() => setLoggedIn());
 
       describe('when data is returned', () => {
         beforeEach(() => {
@@ -115,9 +101,7 @@ describe('notes data', () => {
 
   describe('addNote', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('returns null', async () => {
         expect(await addNote(note)).toBeNull();
@@ -125,15 +109,12 @@ describe('notes data', () => {
 
       it('does not access the database', async () => {
         await addNote(note);
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(() => setLoggedIn());
 
       describe('when the insert succeeds', () => {
         beforeEach(() => {
@@ -173,9 +154,7 @@ describe('notes data', () => {
 
   describe('canDeleteNote', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('returns false', async () => {
         expect(await canDeleteNote(note)).toBe(false);
@@ -183,9 +162,7 @@ describe('notes data', () => {
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(() => setLoggedIn());
 
       it('returns true', async () => {
         expect(await canDeleteNote(note)).toBe(true);
@@ -199,20 +176,17 @@ describe('notes data', () => {
 
   describe('deleteNote', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('does not access the database', async () => {
         await deleteNote(note);
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
       beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
+        setLoggedIn();
         (executeQuery as Mock).mockResolvedValue(null);
       });
 
@@ -234,9 +208,7 @@ describe('notes data', () => {
 
   describe('updateNote', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('returns null', async () => {
         expect(await updateNote(note)).toBeNull();
@@ -244,15 +216,12 @@ describe('notes data', () => {
 
       it('does not access the database', async () => {
         await updateNote(note);
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(() => setLoggedIn());
 
       describe('when the update succeeds', () => {
         beforeEach(() => {

--- a/app/adventure/notes/__tests__/data.spec.ts
+++ b/app/adventure/notes/__tests__/data.spec.ts
@@ -36,8 +36,8 @@ describe('notes data', () => {
     vi.clearAllMocks();
     const chain = buildChainableMock();
     mockFrom = vi.fn().mockReturnValue(chain);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const client = createClient();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vi.mocked(createClient).mockReturnValue({ ...client, from: mockFrom } as any);
     vi.clearAllMocks();
   });

--- a/app/adventure/notes/data.ts
+++ b/app/adventure/notes/data.ts
@@ -4,7 +4,7 @@
 import { Note, NoteDTO } from '@/models';
 import { convertToNote, convertToNoteDTO } from '@/models/convert';
 import { executeQuery } from '@/utils/data';
-import { isNotLoggedIn } from '@/utils/supabase/auth';
+import { isNotLoggedIn, withAuth } from '@/utils/supabase/auth';
 import { createClient } from '@/utils/supabase/server';
 import { SupabaseClient } from '@supabase/supabase-js';
 
@@ -28,52 +28,25 @@ const noteDelete = (supabase: SupabaseClient, note: Note): any => {
 };
 
 export const fetchNote = async (id: number): Promise<Note | null> => {
-  if (await isNotLoggedIn()) {
-    return null;
-  }
-
-  const supabase = createClient();
-  const query = noteQuery(supabase, id);
-  const data = await executeQuery<NoteDTO>(query);
+  const data = await withAuth((supabase: SupabaseClient) => executeQuery<NoteDTO>(noteQuery(supabase, id)));
   return data ? convertToNote(data) : null;
 };
 
 export const addNote = async (note: Note): Promise<Note | null> => {
-  if (await isNotLoggedIn()) {
-    return null;
-  }
-
-  const supabase = createClient();
-  const query = noteInsert(supabase, note);
-  const data = await executeQuery<NoteDTO>(query);
+  const data = await withAuth((supabase: SupabaseClient) => executeQuery<NoteDTO>(noteInsert(supabase, note)));
   return data ? convertToNote(data) : null;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const canDeleteNote = async (note: Note): Promise<boolean> => {
-  if (await isNotLoggedIn()) {
-    return false;
-  }
-  return true;
+  return !!(await withAuth(async () => true));
 };
 
 export const deleteNote = async (note: Note): Promise<void> => {
-  if (await isNotLoggedIn()) {
-    return;
-  }
-
-  const supabase = createClient();
-  const query = noteDelete(supabase, note);
-  await executeQuery<void>(query);
+  await withAuth((supabase: SupabaseClient) => executeQuery<void>(noteDelete(supabase, note)));
 };
 
 export const updateNote = async (note: Note): Promise<Note | null> => {
-  if (await isNotLoggedIn()) {
-    return null;
-  }
-
-  const supabase = createClient();
-  const query = noteUpdate(supabase, note);
-  const data = await executeQuery<NoteDTO>(query);
+  const data = await withAuth((supabase: SupabaseClient) => executeQuery<NoteDTO>(noteUpdate(supabase, note)));
   return data ? convertToNote(data) : null;
 };

--- a/app/adventure/notes/data.ts
+++ b/app/adventure/notes/data.ts
@@ -4,8 +4,7 @@
 import { Note, NoteDTO } from '@/models';
 import { convertToNote, convertToNoteDTO } from '@/models/convert';
 import { executeQuery } from '@/utils/data';
-import { isNotLoggedIn, withAuth } from '@/utils/supabase/auth';
-import { createClient } from '@/utils/supabase/server';
+import { withAuth } from '@/utils/supabase/auth';
 import { SupabaseClient } from '@supabase/supabase-js';
 
 const selectColumns = '*';

--- a/app/adventure/places/__tests__/data.spec.ts
+++ b/app/adventure/places/__tests__/data.spec.ts
@@ -1,10 +1,9 @@
+import { buildChainableMock, setLoggedIn, setLoggedOut } from '@/test-utils/data-helpers';
 import { executeQuery } from '@/utils/data';
-import { isNotLoggedIn } from '@/utils/supabase/auth';
 import { createClient } from '@/utils/supabase/server';
 import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import { addPlace, canDeletePlace, deletePlace, fetchPlace, fetchPlaces, fetchPlaceTypes, updatePlace } from '../data';
 
-vi.mock('@/utils/supabase/auth');
 vi.mock('@/utils/supabase/server');
 vi.mock('@/utils/data', () => ({ executeQuery: vi.fn() }));
 
@@ -71,16 +70,6 @@ const placeWithNotes = {
   ],
 };
 
-// --- Helpers ---
-
-const buildChainableMock = () => {
-  const chain: Record<string, Mock> = {};
-  ['select', 'insert', 'update', 'delete', 'eq', 'single', 'order'].forEach((method) => {
-    chain[method] = vi.fn().mockReturnValue(chain);
-  });
-  return chain;
-};
-
 // --- Tests ---
 
 describe('places data', () => {
@@ -90,8 +79,10 @@ describe('places data', () => {
     vi.clearAllMocks();
     const chain = buildChainableMock();
     mockFrom = vi.fn().mockReturnValue(chain);
+    const client = createClient();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    vi.mocked(createClient).mockReturnValue({ from: mockFrom } as any);
+    vi.mocked(createClient).mockReturnValue({ ...client, from: mockFrom } as any);
+    vi.clearAllMocks();
   });
 
   // ---------------------------------------------------------------------------
@@ -100,9 +91,7 @@ describe('places data', () => {
 
   describe('fetchPlaces', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('returns an empty array', async () => {
         expect(await fetchPlaces()).toEqual([]);
@@ -110,15 +99,12 @@ describe('places data', () => {
 
       it('does not access the database', async () => {
         await fetchPlaces();
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(() => setLoggedIn());
 
       describe('when data is returned', () => {
         beforeEach(() => {
@@ -158,9 +144,7 @@ describe('places data', () => {
 
   describe.each([true, false])('fetchPlace full: $0', (full: boolean) => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('returns null', async () => {
         expect(await fetchPlace(1, full)).toBeNull();
@@ -168,15 +152,12 @@ describe('places data', () => {
 
       it('does not access the database', async () => {
         await fetchPlace(1, full);
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(() => setLoggedIn());
 
       describe('when data is returned', () => {
         beforeEach(() => {
@@ -216,9 +197,7 @@ describe('places data', () => {
 
   describe('addPlace', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('returns null', async () => {
         expect(await addPlace(place)).toBeNull();
@@ -226,15 +205,12 @@ describe('places data', () => {
 
       it('does not access the database', async () => {
         await addPlace(place);
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(() => setLoggedIn());
 
       describe('when the insert succeeds', () => {
         beforeEach(() => {
@@ -274,9 +250,7 @@ describe('places data', () => {
 
   describe('fetchPlaceTypes', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('returns an empty array', async () => {
         expect(await fetchPlaceTypes()).toEqual([]);
@@ -284,15 +258,12 @@ describe('places data', () => {
 
       it('does not access the database', async () => {
         await fetchPlaceTypes();
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(() => setLoggedIn());
 
       describe('when data is returned', () => {
         beforeEach(() => {
@@ -332,9 +303,7 @@ describe('places data', () => {
 
   describe('canDeletePlace', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('returns false', async () => {
         expect(await canDeletePlace(place)).toBe(false);
@@ -342,15 +311,12 @@ describe('places data', () => {
 
       it('does not access the database', async () => {
         await canDeletePlace(place);
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(() => setLoggedIn());
 
       it('queries the events table', async () => {
         (executeQuery as Mock).mockResolvedValue({ count: 0 });
@@ -396,20 +362,17 @@ describe('places data', () => {
 
   describe('deletePlace', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('does not access the database', async () => {
         await deletePlace(place);
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
       beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
+        setLoggedIn();
         (executeQuery as Mock).mockResolvedValue(null);
       });
 
@@ -431,9 +394,7 @@ describe('places data', () => {
 
   describe('updatePlace', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('returns null', async () => {
         expect(await updatePlace(place)).toBeNull();
@@ -441,15 +402,12 @@ describe('places data', () => {
 
       it('does not access the database', async () => {
         await updatePlace(place);
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(() => setLoggedIn());
 
       describe('when the update succeeds', () => {
         beforeEach(() => {

--- a/app/adventure/places/data.ts
+++ b/app/adventure/places/data.ts
@@ -4,7 +4,7 @@
 import { Place, PlaceDTO, PlaceType } from '@/models';
 import { convertToPlace, convertToPlaceDTO } from '@/models/convert';
 import { executeQuery } from '@/utils/data';
-import { isNotLoggedIn } from '@/utils/supabase/auth';
+import { isNotLoggedIn, withAuth } from '@/utils/supabase/auth';
 import { createClient } from '@/utils/supabase/server';
 import { SupabaseClient } from '@supabase/supabase-js';
 
@@ -51,77 +51,39 @@ const placeTypesQuery = (supabase: SupabaseClient): any => {
 };
 
 export const fetchPlaces = async (): Promise<Place[]> => {
-  if (await isNotLoggedIn()) {
-    return [];
-  }
-
-  const supabase = createClient();
-  const query = placeQuery(supabase);
-  const data = await executeQuery<PlaceDTO[]>(query);
+  const data = await withAuth((supabase: SupabaseClient) => executeQuery<PlaceDTO[]>(placeQuery(supabase)));
   return (data || []).map((p) => convertToPlace(p) as Place);
 };
 
 export const fetchPlace = async (id: number, full?: boolean): Promise<Place | null> => {
-  if (await isNotLoggedIn()) {
-    return null;
-  }
-
-  const supabase = createClient();
-  const query = full ? fullPlaceQuery(supabase, id) : placeQuery(supabase, id);
-  const data = await executeQuery<PlaceDTO>(query);
+  const data = await withAuth((supabase: SupabaseClient) =>
+    executeQuery<PlaceDTO>(full ? fullPlaceQuery(supabase, id) : placeQuery(supabase, id)),
+  );
   return data ? (convertToPlace(data) as Place) : null;
 };
 
 export const addPlace = async (place: Place): Promise<Place | null> => {
-  if (await isNotLoggedIn()) {
-    return null;
-  }
-
-  const supabase = createClient();
-  const query = placeInsert(supabase, place);
-  const data = await executeQuery<PlaceDTO>(query);
+  const data = await withAuth((supabase: SupabaseClient) => executeQuery<PlaceDTO>(placeInsert(supabase, place)));
   return data ? (convertToPlace(data) as Place) : null;
 };
 
 export const fetchPlaceTypes = async (): Promise<PlaceType[]> => {
-  if (await isNotLoggedIn()) {
-    return [];
-  }
-
-  const supabase = createClient();
-  const query = placeTypesQuery(supabase);
-  const data = await executeQuery<PlaceType[]>(query);
+  const data = await withAuth((supabase: SupabaseClient) => executeQuery<PlaceType[]>(placeTypesQuery(supabase)));
   return data || [];
 };
 
 export const canDeletePlace = async (place: Place): Promise<boolean> => {
-  if (await isNotLoggedIn()) {
-    return false;
-  }
-
-  const supabase = createClient();
-  const query = usageCountInEvents(supabase, place);
-  const data = await executeQuery<{ count: number }>(query);
+  const data = await withAuth((supabase: SupabaseClient) =>
+    executeQuery<{ count: number }>(usageCountInEvents(supabase, place)),
+  );
   return data?.count === 0;
 };
 
 export const deletePlace = async (place: Place): Promise<void> => {
-  if (await isNotLoggedIn()) {
-    return;
-  }
-
-  const supabase = createClient();
-  const query = placeDelete(supabase, place);
-  await executeQuery(query);
+  await withAuth((supabase: SupabaseClient) => executeQuery(placeDelete(supabase, place)));
 };
 
 export const updatePlace = async (place: Place): Promise<Place | null> => {
-  if (await isNotLoggedIn()) {
-    return null;
-  }
-
-  const supabase = createClient();
-  const query = placeUpdate(supabase, place);
-  const data = await executeQuery<PlaceDTO>(query);
+  const data = await withAuth((supabase: SupabaseClient) => executeQuery<PlaceDTO>(placeUpdate(supabase, place)));
   return data ? (convertToPlace(data) as Place) : null;
 };

--- a/app/adventure/places/data.ts
+++ b/app/adventure/places/data.ts
@@ -4,8 +4,7 @@
 import { Place, PlaceDTO, PlaceType } from '@/models';
 import { convertToPlace, convertToPlaceDTO } from '@/models/convert';
 import { executeQuery } from '@/utils/data';
-import { isNotLoggedIn, withAuth } from '@/utils/supabase/auth';
-import { createClient } from '@/utils/supabase/server';
+import { withAuth } from '@/utils/supabase/auth';
 import { SupabaseClient } from '@supabase/supabase-js';
 
 const placesTable = 'places';

--- a/app/adventure/todos/__tests__/data.spec.ts
+++ b/app/adventure/todos/__tests__/data.spec.ts
@@ -1,5 +1,4 @@
 import { executeQuery } from '@/utils/data';
-import { isNotLoggedIn } from '@/utils/supabase/auth';
 import { createClient } from '@/utils/supabase/server';
 import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import {
@@ -15,8 +14,8 @@ import {
   updateTodoCollection,
   updateTodoItem,
 } from '../data';
+import { buildChainableMock, setLoggedIn, setLoggedOut } from '@/test-utils/data-helpers';
 
-vi.mock('@/utils/supabase/auth');
 vi.mock('@/utils/supabase/server');
 vi.mock('@/utils/data', () => ({ executeQuery: vi.fn() }));
 
@@ -70,16 +69,6 @@ const todoCollectionWithItems = {
   todoItems: [todoItem],
 };
 
-// --- Helpers ---
-
-const buildChainableMock = () => {
-  const chain: Record<string, Mock> = {};
-  ['select', 'insert', 'update', 'delete', 'eq', 'single', 'order', 'lt'].forEach((method) => {
-    chain[method] = vi.fn().mockReturnValue(chain);
-  });
-  return chain;
-};
-
 // --- Tests ---
 
 describe('todos data', () => {
@@ -89,8 +78,10 @@ describe('todos data', () => {
     vi.clearAllMocks();
     const chain = buildChainableMock();
     mockFrom = vi.fn().mockReturnValue(chain);
+    const client = createClient();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    vi.mocked(createClient).mockReturnValue({ from: mockFrom } as any);
+    vi.mocked(createClient).mockReturnValue({ ...client, from: mockFrom } as any);
+    vi.clearAllMocks();
   });
 
   // ---------------------------------------------------------------------------
@@ -99,9 +90,7 @@ describe('todos data', () => {
 
   describe('fetchTodoCollections', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('returns an empty array', async () => {
         expect(await fetchTodoCollections()).toEqual([]);
@@ -109,15 +98,12 @@ describe('todos data', () => {
 
       it('does not access the database', async () => {
         await fetchTodoCollections();
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(() => setLoggedIn());
 
       describe('when data is returned', () => {
         beforeEach(() => {
@@ -162,9 +148,7 @@ describe('todos data', () => {
 
   describe('fetchTodoCollection', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('returns null', async () => {
         expect(await fetchTodoCollection(1)).toBeNull();
@@ -172,15 +156,12 @@ describe('todos data', () => {
 
       it('does not access the database', async () => {
         await fetchTodoCollection(1);
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(() => setLoggedIn());
 
       describe('when data is returned', () => {
         beforeEach(() => {
@@ -225,9 +206,7 @@ describe('todos data', () => {
 
   describe('fetchDueTodoCollections', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('returns an empty array', async () => {
         expect(await fetchDueTodoCollections('2025-07-01')).toEqual([]);
@@ -235,15 +214,12 @@ describe('todos data', () => {
 
       it('does not access the database', async () => {
         await fetchDueTodoCollections('2025-07-01');
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(() => setLoggedIn());
 
       describe('when data is returned', () => {
         beforeEach(() => {
@@ -283,9 +259,7 @@ describe('todos data', () => {
 
   describe('addTodoCollection', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('returns null', async () => {
         expect(await addTodoCollection(todoCollection)).toBeNull();
@@ -293,15 +267,12 @@ describe('todos data', () => {
 
       it('does not access the database', async () => {
         await addTodoCollection(todoCollection);
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(() => setLoggedIn());
 
       describe('when the insert succeeds', () => {
         beforeEach(() => {
@@ -341,9 +312,7 @@ describe('todos data', () => {
 
   describe('canDeleteTodoCollection', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('returns false', async () => {
         expect(await canDeleteTodoCollection(todoCollection)).toBe(false);
@@ -351,9 +320,7 @@ describe('todos data', () => {
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(() => setLoggedIn());
 
       it('returns true', async () => {
         expect(await canDeleteTodoCollection(todoCollection)).toBe(true);
@@ -367,20 +334,17 @@ describe('todos data', () => {
 
   describe('deleteTodoCollection', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('does not access the database', async () => {
         await deleteTodoCollection(todoCollection);
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
       beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
+        setLoggedIn();
         (executeQuery as Mock).mockResolvedValue(null);
       });
 
@@ -402,9 +366,7 @@ describe('todos data', () => {
 
   describe('updateTodoCollection', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('returns null', async () => {
         expect(await updateTodoCollection(todoCollection)).toBeNull();
@@ -412,15 +374,12 @@ describe('todos data', () => {
 
       it('does not access the database', async () => {
         await updateTodoCollection(todoCollection);
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(() => setLoggedIn());
 
       describe('when the update succeeds', () => {
         beforeEach(() => {
@@ -460,9 +419,7 @@ describe('todos data', () => {
 
   describe('addTodoItem', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('returns null', async () => {
         expect(await addTodoItem(todoItem)).toBeNull();
@@ -470,15 +427,12 @@ describe('todos data', () => {
 
       it('does not access the database', async () => {
         await addTodoItem(todoItem);
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(() => setLoggedIn());
 
       describe('when the insert succeeds', () => {
         beforeEach(() => {
@@ -518,9 +472,7 @@ describe('todos data', () => {
 
   describe('canDeleteTodoItem', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('returns false', async () => {
         expect(await canDeleteTodoItem(todoItem)).toBe(false);
@@ -528,9 +480,7 @@ describe('todos data', () => {
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(() => setLoggedIn());
 
       it('returns true', async () => {
         expect(await canDeleteTodoItem(todoItem)).toBe(true);
@@ -544,20 +494,17 @@ describe('todos data', () => {
 
   describe('deleteTodoItem', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('does not access the database', async () => {
         await deleteTodoItem(todoItem);
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
       beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
+        setLoggedIn();
         (executeQuery as Mock).mockResolvedValue(null);
       });
 
@@ -579,9 +526,7 @@ describe('todos data', () => {
 
   describe('updateTodoItem', () => {
     describe('when not logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(true);
-      });
+      beforeEach(() => setLoggedOut());
 
       it('returns null', async () => {
         expect(await updateTodoItem(todoItem)).toBeNull();
@@ -589,15 +534,12 @@ describe('todos data', () => {
 
       it('does not access the database', async () => {
         await updateTodoItem(todoItem);
-        expect(createClient).not.toHaveBeenCalled();
         expect(executeQuery).not.toHaveBeenCalled();
       });
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        (isNotLoggedIn as Mock).mockResolvedValue(false);
-      });
+      beforeEach(() => setLoggedIn());
 
       describe('when the update succeeds', () => {
         beforeEach(() => {

--- a/app/adventure/todos/data.ts
+++ b/app/adventure/todos/data.ts
@@ -9,8 +9,7 @@ import {
   convertToTodoItemDTO,
 } from '@/models/convert';
 import { executeQuery } from '@/utils/data';
-import { isNotLoggedIn } from '@/utils/supabase/auth';
-import { createClient } from '@/utils/supabase/server';
+import { withAuth } from '@/utils/supabase/auth';
 import { SupabaseClient } from '@supabase/supabase-js';
 
 const collectionSelectColumns =
@@ -68,114 +67,64 @@ const todoItemDelete = (supabase: SupabaseClient, item: TodoItem): any =>
   supabase.from(itemTable).delete().eq('id', item.id);
 
 export const fetchTodoCollections = async (): Promise<TodoCollection[]> => {
-  if (await isNotLoggedIn()) {
-    return [];
-  }
-
-  const supabase = createClient();
-  const query = todoCollectionQuery(supabase);
-  const data = await executeQuery<TodoCollectionDTO[]>(query);
+  const data = await withAuth((supabase: SupabaseClient) =>
+    executeQuery<TodoCollectionDTO[]>(todoCollectionQuery(supabase)),
+  );
   return (data || []).map((p) => convertToTodoCollection(p) as TodoCollection);
 };
 
 export const fetchTodoCollection = async (id: number): Promise<TodoCollection | null> => {
-  if (await isNotLoggedIn()) {
-    return null;
-  }
-
-  const supabase = createClient();
-  const query = todoCollectionQuery(supabase, id);
-  const data = await executeQuery<TodoCollectionDTO>(query);
+  const data = await withAuth((supabase: SupabaseClient) =>
+    executeQuery<TodoCollectionDTO>(todoCollectionQuery(supabase, id)),
+  );
   return data && (convertToTodoCollection(data) as TodoCollection);
 };
 
 export const fetchDueTodoCollections = async (dueDate: string): Promise<TodoCollection[]> => {
-  if (await isNotLoggedIn()) {
-    return [];
-  }
-
-  const supabase = createClient();
-  const query = dueTodoCollectionQuery(supabase, dueDate);
-  const data = await executeQuery<TodoCollectionDTO[]>(query);
+  const data = await withAuth((supabase: SupabaseClient) =>
+    executeQuery<TodoCollectionDTO[]>(dueTodoCollectionQuery(supabase, dueDate)),
+  );
   return (data || []).map((p) => convertToTodoCollection(p) as TodoCollection);
 };
 
 export const addTodoCollection = async (collection: TodoCollection): Promise<TodoCollection | null> => {
-  if (await isNotLoggedIn()) {
-    return null;
-  }
-
-  const supabase = createClient();
-  const query = todoCollectionInsert(supabase, collection);
-  const data = await executeQuery<TodoCollectionDTO>(query);
+  const data = await withAuth((supabase: SupabaseClient) =>
+    executeQuery<TodoCollectionDTO>(todoCollectionInsert(supabase, collection)),
+  );
   return data && (convertToTodoCollection(data) as TodoCollection);
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const canDeleteTodoCollection = async (collection: TodoCollection): Promise<boolean> => {
-  if (await isNotLoggedIn()) {
-    return false;
-  }
-  return true;
+  return !!(await withAuth(async () => true));
 };
 
 export const deleteTodoCollection = async (collection: TodoCollection): Promise<void> => {
-  if (await isNotLoggedIn()) {
-    return;
-  }
-
-  const supabase = createClient();
-  const query = todoCollectionDelete(supabase, collection);
-  await executeQuery<void>(query);
+  await withAuth((supabase: SupabaseClient) => executeQuery<void>(todoCollectionDelete(supabase, collection)));
 };
 
 export const updateTodoCollection = async (collection: TodoCollection): Promise<TodoCollection | null> => {
-  if (await isNotLoggedIn()) {
-    return null;
-  }
-
-  const supabase = createClient();
-  const query = todoCollectionUpdate(supabase, collection);
-  const data = await executeQuery<TodoCollectionDTO>(query);
+  const data = await withAuth((supabase: SupabaseClient) =>
+    executeQuery<TodoCollectionDTO>(todoCollectionUpdate(supabase, collection)),
+  );
   return data && (convertToTodoCollection(data) as TodoCollection);
 };
 
 export const addTodoItem = async (item: TodoItem): Promise<TodoItem | null> => {
-  if (await isNotLoggedIn()) {
-    return null;
-  }
-
-  const supabase = createClient();
-  const query = todoItemInsert(supabase, item);
-  const data = await executeQuery<TodoItemDTO>(query);
+  const data = await withAuth((supabase: SupabaseClient) => executeQuery<TodoItemDTO>(todoItemInsert(supabase, item)));
   return data && (convertToTodoItem(data) as TodoItem);
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const canDeleteTodoItem = async (item: TodoItem): Promise<boolean> => {
-  if (await isNotLoggedIn()) {
-    return false;
-  }
-  return true;
+  return !!(await withAuth(async () => true));
 };
 
 export const deleteTodoItem = async (item: TodoItem): Promise<void> => {
-  if (await isNotLoggedIn()) {
-    return;
-  }
-
-  const supabase = createClient();
-  const query = todoItemDelete(supabase, item);
-  await executeQuery<void>(query);
+  await withAuth((supabase: SupabaseClient) => executeQuery<void>(todoItemDelete(supabase, item)));
 };
 
 export const updateTodoItem = async (item: TodoItem): Promise<TodoItem | null> => {
-  if (await isNotLoggedIn()) {
-    return null;
-  }
-
-  const supabase = createClient();
-  const query = todoItemUpdate(supabase, item);
-  const data = await executeQuery<TodoItemDTO>(query);
+  const data = await withAuth((supabase: SupabaseClient) => executeQuery<TodoItemDTO>(todoItemUpdate(supabase, item)));
   return data && (convertToTodoItem(data) as TodoItem);
 };

--- a/package.json
+++ b/package.json
@@ -66,5 +66,5 @@
       "unrs-resolver"
     ]
   },
-  "packageManager": "pnpm@10.33.0"
+  "packageManager": "pnpm@10.33.2"
 }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
   "prettier": "@ionic/prettier-config",
   "lint-staged": {
     "*.{js,jsx,ts,tsx,css,md,json}": [
-      "prettier --write"
+      "prettier --write",
+      "eslint"
     ]
   },
   "pnpm": {

--- a/test-utils/data-helpers.ts
+++ b/test-utils/data-helpers.ts
@@ -1,0 +1,22 @@
+import { createClient } from '@/utils/supabase/server';
+import { type Mock, vi } from 'vitest';
+
+export const buildChainableMock = () => {
+  const chain: Record<string, Mock> = {};
+  ['select', 'insert', 'update', 'delete', 'eq', 'single', 'order', 'or', 'limit'].forEach((method) => {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  });
+  return chain;
+};
+
+export const setLoggedOut = () => {
+  const client = createClient();
+  (client.auth.getUser as Mock).mockResolvedValue({ data: { user: null }, error: null });
+  vi.clearAllMocks();
+};
+
+export const setLoggedIn = () => {
+  const client = createClient();
+  (client.auth.getUser as Mock).mockResolvedValue({ data: { user: { id: 'foo', name: 'Bar Baz' } }, error: null });
+  vi.clearAllMocks();
+};

--- a/test-utils/data-helpers.ts
+++ b/test-utils/data-helpers.ts
@@ -11,12 +11,14 @@ export const buildChainableMock = () => {
 
 export const setLoggedOut = () => {
   const client = createClient();
+  (createClient as Mock).mockClear();
+  (client.auth.getUser as Mock).mockClear();
   (client.auth.getUser as Mock).mockResolvedValue({ data: { user: null }, error: null });
-  vi.clearAllMocks();
 };
 
 export const setLoggedIn = () => {
   const client = createClient();
+  (createClient as Mock).mockClear();
+  (client.auth.getUser as Mock).mockClear();
   (client.auth.getUser as Mock).mockResolvedValue({ data: { user: { id: 'foo', name: 'Bar Baz' } }, error: null });
-  vi.clearAllMocks();
 };

--- a/test-utils/data-helpers.ts
+++ b/test-utils/data-helpers.ts
@@ -3,7 +3,7 @@ import { type Mock, vi } from 'vitest';
 
 export const buildChainableMock = () => {
   const chain: Record<string, Mock> = {};
-  ['select', 'insert', 'update', 'delete', 'eq', 'single', 'order', 'or', 'limit'].forEach((method) => {
+  ['select', 'insert', 'update', 'delete', 'eq', 'gt', 'lt', 'single', 'order', 'or', 'limit'].forEach((method) => {
     chain[method] = vi.fn().mockReturnValue(chain);
   });
   return chain;

--- a/utils/supabase/__tests__/auth.spec.ts
+++ b/utils/supabase/__tests__/auth.spec.ts
@@ -28,6 +28,7 @@ describe('withAuth', () => {
 
   beforeEach(() => {
     mockFn.mockReset();
+    mockCreateClient.mockClear();
   });
 
   it('calls fn with the supabase client when a user is logged in', async () => {

--- a/utils/supabase/__tests__/auth.spec.ts
+++ b/utils/supabase/__tests__/auth.spec.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createClient } from '../server';
+import { isNotLoggedIn, withAuth } from '../auth';
+
+vi.mock('../server');
+
+const mockCreateClient = vi.mocked(createClient);
+
+describe('isNotLoggedIn', () => {
+  it('returns false when a user is logged in', async () => {
+    expect(await isNotLoggedIn()).toBe(false);
+  });
+
+  it('returns true when no user is logged in', async () => {
+    mockCreateClient.mockReturnValueOnce({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({ data: { user: null } }),
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    expect(await isNotLoggedIn()).toBe(true);
+  });
+});
+
+describe('withAuth', () => {
+  const mockFn = vi.fn();
+
+  beforeEach(() => {
+    mockFn.mockReset();
+  });
+
+  it('calls fn with the supabase client when a user is logged in', async () => {
+    mockFn.mockResolvedValue('result');
+    const result = await withAuth(mockFn);
+
+    expect(mockFn).toHaveBeenCalledOnce();
+    expect(result).toBe('result');
+  });
+
+  it('passes the supabase client to fn', async () => {
+    mockFn.mockResolvedValue(null);
+    await withAuth(mockFn);
+
+    const supabase = mockCreateClient.mock.results[0].value;
+    expect(mockFn).toHaveBeenCalledWith(supabase);
+  });
+
+  it('returns null when no user is logged in', async () => {
+    mockCreateClient.mockReturnValueOnce({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({ data: { user: null } }),
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const result = await withAuth(mockFn);
+
+    expect(mockFn).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+});

--- a/utils/supabase/auth.ts
+++ b/utils/supabase/auth.ts
@@ -1,3 +1,4 @@
+import { SupabaseClient } from '@supabase/supabase-js';
 import { createClient } from './server';
 
 export const isNotLoggedIn = async (): Promise<boolean> => {
@@ -8,4 +9,16 @@ export const isNotLoggedIn = async (): Promise<boolean> => {
   } = await supabase.auth.getUser();
 
   return !user;
+};
+
+export const withAuth = <TArgs extends unknown[], TResult>(
+  fn: (supabase: SupabaseClient, ...args: TArgs) => Promise<TResult>,
+): ((...args: TArgs) => Promise<TResult | null>) => {
+  return async (...args) => {
+    const supabase = createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    return user ? fn(supabase, ...args) : null;
+  };
 };

--- a/utils/supabase/auth.ts
+++ b/utils/supabase/auth.ts
@@ -11,14 +11,14 @@ export const isNotLoggedIn = async (): Promise<boolean> => {
   return !user;
 };
 
-export const withAuth = <TArgs extends unknown[], TResult>(
-  fn: (supabase: SupabaseClient, ...args: TArgs) => Promise<TResult>,
-): ((...args: TArgs) => Promise<TResult | null>) => {
-  return async (...args) => {
+export const withAuth = <TResult>(
+  fn: (supabase: SupabaseClient) => Promise<TResult>,
+): (() => Promise<TResult | null>) => {
+  return async () => {
     const supabase = createClient();
     const {
       data: { user },
     } = await supabase.auth.getUser();
-    return user ? fn(supabase, ...args) : null;
+    return user ? fn(supabase) : null;
   };
 };

--- a/utils/supabase/auth.ts
+++ b/utils/supabase/auth.ts
@@ -11,14 +11,12 @@ export const isNotLoggedIn = async (): Promise<boolean> => {
   return !user;
 };
 
-export const withAuth = <TResult>(
+export const withAuth = async <TResult>(
   fn: (supabase: SupabaseClient) => Promise<TResult>,
-): (() => Promise<TResult | null>) => {
-  return async () => {
-    const supabase = createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-    return user ? fn(supabase) : null;
-  };
+): Promise<TResult | null> => {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  return user ? await fn(supabase) : null;
 };


### PR DESCRIPTION
Guards database authorization by wrapping queries in a single higher-order function, `withAuth`. This refactoring significantly cleans up the data layer by centralizing authentication checks and Supabase client initialization.

Key changes include:
- **Introduce `withAuth` HOF**: A new utility function that automatically checks user authentication before executing a provided database query function with a Supabase client. If the user is not logged in, it gracefully returns `null` or an empty array.
- **Refactor data access functions**: Update all existing data fetching, adding, updating, and deleting functions across equipment, itinerary, events, notes, places, and todo modules to leverage the `withAuth` HOF, removing repetitive boilerplate.
- **Enhance test utilities**: Extract common test setup helpers (`buildChainableMock`, `setLoggedIn`, `setLoggedOut`) into a new shared `test-utils/data-helpers.ts` module, improving test clarity and reducing duplication.
- **Add unit tests**: Include new tests for the `withAuth` function to ensure its reliable operation.
- **Update lint-staged**: Add `eslint` to the pre-commit hooks for JavaScript/TypeScript files.

Relates to #26