### PR TITLE
Introduce typed `QueryResult` for data operations

### DIFF
--- a/.changeset/loose-mirrors-ask.md
+++ b/.changeset/loose-mirrors-ask.md
@@ -1,0 +1,5 @@
+---
+'recreation-planner': patch
+---
+
+Return a QueryResult structure rather than just data. This allows the system to know the exact status of a data transaction.

--- a/app/adventure/equipment/[id]/delete/__tests__/action.spec.ts
+++ b/app/adventure/equipment/[id]/delete/__tests__/action.spec.ts
@@ -1,6 +1,6 @@
 import { Equipment } from '@/models';
 import { redirect } from 'next/navigation';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import { deleteEquipment } from '../../../data';
 import { deleteAborted, deleteConfirmed } from '../actions';
 
@@ -49,9 +49,16 @@ describe('equipment: delete actions', () => {
       expect(deleteEquipment).toHaveBeenCalledExactlyOnceWith(equipment);
     });
 
-    it('redirects to /adventure/equipment', async () => {
+    it('redirects to /adventure/equipment if the delete succeeds', async () => {
+      (deleteEquipment as Mock).mockResolvedValue(true);
       await deleteConfirmed(equipment).catch(() => {});
       expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/equipment');
+    });
+
+    it('redirects to /error if the delete fails', async () => {
+      (deleteEquipment as Mock).mockResolvedValue(false);
+      await deleteConfirmed(equipment).catch(() => {});
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
     });
   });
 });

--- a/app/adventure/equipment/[id]/delete/actions.ts
+++ b/app/adventure/equipment/[id]/delete/actions.ts
@@ -5,8 +5,11 @@ import { redirect } from 'next/navigation';
 import { deleteEquipment } from '../../data';
 
 export const deleteConfirmed = async (e: Equipment) => {
-  await deleteEquipment(e);
-  redirect('/adventure/equipment');
+  if (await deleteEquipment(e)) {
+    redirect('/adventure/equipment');
+  } else {
+    redirect('/error');
+  }
 };
 
 export const deleteAborted = async () => {

--- a/app/adventure/equipment/[id]/notes/[noteId]/delete/__tests__/actions.spec.ts
+++ b/app/adventure/equipment/[id]/notes/[noteId]/delete/__tests__/actions.spec.ts
@@ -1,5 +1,5 @@
 import { Note } from '@/models';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 import { deleteAborted, deleteConfirmed } from '../actions';
 import { deleteNote } from '@/app/adventure/notes/data';
 import { redirect } from 'next/navigation';
@@ -21,24 +21,31 @@ describe('equipment notes: delete actions', () => {
 
   describe('deleteConfirmed', () => {
     it('calls deleteNote', async () => {
-      await deleteConfirmed(19, note);
+      await deleteConfirmed(19, note).catch(() => {});
       expect(deleteNote).toHaveBeenCalledExactlyOnceWith(note);
     });
 
-    it('redirects to the equipment details page', async () => {
-      await deleteConfirmed(19, note);
+    it('redirects to the equipment details page if the delete succeeds', async () => {
+      (deleteNote as Mock).mockResolvedValue(true);
+      await deleteConfirmed(19, note).catch(() => {});
       expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/equipment/19?lastActivity=Notes');
+    });
+
+    it('redirects to /error if the delete fails', async () => {
+      (deleteNote as Mock).mockResolvedValue(false);
+      await deleteConfirmed(19, note).catch(() => {});
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
     });
   });
 
   describe('deleteAborted', () => {
     it('does not call deleteNote', async () => {
-      await deleteAborted(19);
+      await deleteAborted(19).catch(() => {});
       expect(deleteNote).not.toHaveBeenCalled();
     });
 
     it('redirects to the equipment details page', async () => {
-      await deleteAborted(19);
+      await deleteAborted(19).catch(() => {});
       expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/equipment/19?lastActivity=Notes');
     });
   });

--- a/app/adventure/equipment/[id]/notes/[noteId]/delete/actions.ts
+++ b/app/adventure/equipment/[id]/notes/[noteId]/delete/actions.ts
@@ -2,11 +2,15 @@
 
 import { deleteNote } from '@/app/adventure/notes/data';
 import { Note } from '@/models';
+import { redirect } from 'next/navigation';
 import { redirectToEquipmentDetails } from '../../utils';
 
 export const deleteConfirmed = async (equipmentId: number, n: Note) => {
-  await deleteNote(n);
-  redirectToEquipmentDetails(equipmentId);
+  if (await deleteNote(n)) {
+    redirectToEquipmentDetails(equipmentId);
+  } else {
+    redirect('/error');
+  }
 };
 
 export const deleteAborted = async (equipmentId: number) => {

--- a/app/adventure/equipment/[id]/todos/[collectionId]/delete/__tests__/actions.spec.ts
+++ b/app/adventure/equipment/[id]/todos/[collectionId]/delete/__tests__/actions.spec.ts
@@ -2,7 +2,7 @@ import { TODO_COLLECTIONS } from '@/app/adventure/todos/__mocks__/data';
 import { deleteTodoCollection } from '@/app/adventure/todos/data';
 import { TodoCollection } from '@/models';
 import { redirect } from 'next/navigation';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 import { deleteAborted, deleteConfirmed } from '../actions';
 
 vi.mock('@/app/adventure/todos/data');
@@ -15,24 +15,31 @@ describe('equipment TODOs: delete actions', () => {
 
   describe('deleteConfirmed', () => {
     it('calls deleteTodoCollection', async () => {
-      await deleteConfirmed(19, collection);
+      await deleteConfirmed(19, collection).catch(() => {});
       expect(deleteTodoCollection).toHaveBeenCalledExactlyOnceWith(collection);
     });
 
-    it('redirects to the equipment details page', async () => {
-      await deleteConfirmed(19, collection);
+    it('redirects to the equipment details page if the delete succeeds', async () => {
+      (deleteTodoCollection as Mock).mockResolvedValue(true);
+      await deleteConfirmed(19, collection).catch(() => {});
       expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/equipment/19?lastActivity=Todos');
+    });
+
+    it('redirects to /error if the delete fails', async () => {
+      (deleteTodoCollection as Mock).mockResolvedValue(false);
+      await deleteConfirmed(19, collection).catch(() => {});
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
     });
   });
 
   describe('deleteAborted', () => {
     it('does not call deleteTodoCollection', async () => {
-      await deleteAborted(19);
+      await deleteAborted(19).catch(() => {});
       expect(deleteTodoCollection).not.toHaveBeenCalled();
     });
 
     it('redirects to the equipment details page', async () => {
-      await deleteAborted(19);
+      await deleteAborted(19).catch(() => {});
       expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/equipment/19?lastActivity=Todos');
     });
   });

--- a/app/adventure/equipment/[id]/todos/[collectionId]/delete/actions.ts
+++ b/app/adventure/equipment/[id]/todos/[collectionId]/delete/actions.ts
@@ -2,11 +2,15 @@
 
 import { deleteTodoCollection } from '@/app/adventure/todos/data';
 import { TodoCollection } from '@/models';
+import { redirect } from 'next/navigation';
 import { redirectToEquipmentDetails } from '../../utils';
 
 export const deleteConfirmed = async (equipmentId: number, c: TodoCollection) => {
-  await deleteTodoCollection(c);
-  redirectToEquipmentDetails(equipmentId);
+  if (await deleteTodoCollection(c)) {
+    redirectToEquipmentDetails(equipmentId);
+  } else {
+    redirect('/error');
+  }
 };
 
 export const deleteAborted = async (equipmentId: number) => {

--- a/app/adventure/equipment/__mocks__/data.ts
+++ b/app/adventure/equipment/__mocks__/data.ts
@@ -201,7 +201,7 @@ export const fetchEquipment = vi.fn().mockImplementation((id: number, full?: boo
 export const fetchEquipmentTypes = vi.fn().mockResolvedValue(EQUIPMENT_TYPES);
 export const addEquipment = vi.fn();
 export const updateEquipment = vi.fn();
-export const deleteEquipment = vi.fn();
+export const deleteEquipment = vi.fn().mockResolvedValue(true);
 export const canDeleteEquipment = vi.fn().mockResolvedValue(false);
 export const fetchMaintenanceItem = vi
   .fn()

--- a/app/adventure/equipment/__tests__/data.spec.ts
+++ b/app/adventure/equipment/__tests__/data.spec.ts
@@ -302,6 +302,10 @@ describe('equipment data', () => {
     describe('when not logged in', () => {
       beforeEach(() => setLoggedOut());
 
+      it('returns false', async () => {
+        expect(await deleteEquipment(equipment)).toBe(false);
+      });
+
       it('does not access the database', async () => {
         await deleteEquipment(equipment);
         expect(executeQuery).not.toHaveBeenCalled();
@@ -309,19 +313,36 @@ describe('equipment data', () => {
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        setLoggedIn();
-        (executeQuery as Mock).mockResolvedValue({ success: true, data: null });
+      describe('when the delete succeeds', () => {
+        beforeEach(() => {
+          setLoggedIn();
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: null });
+        });
+
+        it('calls executeQuery', async () => {
+          await deleteEquipment(equipment);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('deletes from the equipment table', async () => {
+          await deleteEquipment(equipment);
+          expect(mockFrom).toHaveBeenCalledWith('equipment');
+        });
+
+        it('returns true', async () => {
+          expect(await deleteEquipment(equipment)).toBe(true);
+        });
       });
 
-      it('calls executeQuery', async () => {
-        await deleteEquipment(equipment);
-        expect(executeQuery).toHaveBeenCalledOnce();
-      });
+      describe('when the delete fails', () => {
+        beforeEach(() => {
+          setLoggedIn();
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'SERVER_ERROR' });
+        });
 
-      it('deletes from the equipment table', async () => {
-        await deleteEquipment(equipment);
-        expect(mockFrom).toHaveBeenCalledWith('equipment');
+        it('returns false', async () => {
+          expect(await deleteEquipment(equipment)).toBe(false);
+        });
       });
     });
   });
@@ -568,6 +589,10 @@ describe('equipment data', () => {
     describe('when not logged in', () => {
       beforeEach(() => setLoggedOut());
 
+      it('returns false', async () => {
+        expect(await deleteMaintenanceItem(maintenanceItem)).toBe(false);
+      });
+
       it('does not access the database', async () => {
         await deleteMaintenanceItem(maintenanceItem);
         expect(executeQuery).not.toHaveBeenCalled();
@@ -575,19 +600,36 @@ describe('equipment data', () => {
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        setLoggedIn();
-        (executeQuery as Mock).mockResolvedValue({ success: true, data: null });
+      describe('when the delete succeeds', () => {
+        beforeEach(() => {
+          setLoggedIn();
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: null });
+        });
+
+        it('calls executeQuery', async () => {
+          await deleteMaintenanceItem(maintenanceItem);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('deletes from the maintenance_items table', async () => {
+          await deleteMaintenanceItem(maintenanceItem);
+          expect(mockFrom).toHaveBeenCalledWith('maintenance_items');
+        });
+
+        it('returns true', async () => {
+          expect(await deleteMaintenanceItem(maintenanceItem)).toBe(true);
+        });
       });
 
-      it('calls executeQuery', async () => {
-        await deleteMaintenanceItem(maintenanceItem);
-        expect(executeQuery).toHaveBeenCalledOnce();
-      });
+      describe('when the delete fails', () => {
+        beforeEach(() => {
+          setLoggedIn();
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'SERVER_ERROR' });
+        });
 
-      it('deletes from the maintenance_items table', async () => {
-        await deleteMaintenanceItem(maintenanceItem);
-        expect(mockFrom).toHaveBeenCalledWith('maintenance_items');
+        it('returns false', async () => {
+          expect(await deleteMaintenanceItem(maintenanceItem)).toBe(false);
+        });
       });
     });
   });

--- a/app/adventure/equipment/__tests__/data.spec.ts
+++ b/app/adventure/equipment/__tests__/data.spec.ts
@@ -136,7 +136,7 @@ describe('equipment data', () => {
 
       describe('when data is returned', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue([equipmentDTO]);
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: [equipmentDTO] });
         });
 
         it('calls executeQuery', async () => {
@@ -154,9 +154,9 @@ describe('equipment data', () => {
         });
       });
 
-      describe('when no data is returned', () => {
+      describe('on error', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(null);
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'NOT_FOUND' });
         });
 
         it('returns an empty array', async () => {
@@ -189,7 +189,7 @@ describe('equipment data', () => {
 
       describe('when data is returned', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(equipmentDTO);
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: equipmentDTO });
         });
 
         it('calls executeQuery', async () => {
@@ -207,9 +207,9 @@ describe('equipment data', () => {
         });
       });
 
-      describe('when no data is returned', () => {
+      describe('on error', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(null);
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'NOT_FOUND' });
         });
 
         it('returns null', async () => {
@@ -242,7 +242,7 @@ describe('equipment data', () => {
 
       describe('when the insert succeeds', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(equipmentDTO);
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: equipmentDTO });
         });
 
         it('calls executeQuery', async () => {
@@ -260,9 +260,9 @@ describe('equipment data', () => {
         });
       });
 
-      describe('when the insert fails', () => {
+      describe('on error', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(null);
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'SERVER_ERROR' });
         });
 
         it('returns null', async () => {
@@ -311,7 +311,7 @@ describe('equipment data', () => {
     describe('when logged in', () => {
       beforeEach(() => {
         setLoggedIn();
-        (executeQuery as Mock).mockResolvedValue(null);
+        (executeQuery as Mock).mockResolvedValue({ success: true, data: null });
       });
 
       it('calls executeQuery', async () => {
@@ -349,7 +349,7 @@ describe('equipment data', () => {
 
       describe('when the update succeeds', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(equipmentDTO);
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: equipmentDTO });
         });
 
         it('calls executeQuery', async () => {
@@ -367,9 +367,9 @@ describe('equipment data', () => {
         });
       });
 
-      describe('when the update fails', () => {
+      describe('on error', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(null);
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'SERVER_ERROR' });
         });
 
         it('returns null', async () => {
@@ -402,7 +402,7 @@ describe('equipment data', () => {
 
       describe('when data is returned', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue([equipmentTypeDTO]);
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: [equipmentTypeDTO] });
         });
 
         it('calls executeQuery', async () => {
@@ -420,9 +420,9 @@ describe('equipment data', () => {
         });
       });
 
-      describe('when no data is returned', () => {
+      describe('on error', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(null);
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'SERVER_ERROR' });
         });
 
         it('returns an empty array', async () => {
@@ -455,7 +455,7 @@ describe('equipment data', () => {
 
       describe('when data is returned', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(maintenanceItemDTO);
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: maintenanceItemDTO });
         });
 
         it('calls executeQuery', async () => {
@@ -473,9 +473,9 @@ describe('equipment data', () => {
         });
       });
 
-      describe('when no data is returned', () => {
+      describe('on error', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(null);
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'NOT_FOUND' });
         });
 
         it('returns null', async () => {
@@ -508,7 +508,7 @@ describe('equipment data', () => {
 
       describe('when the insert succeeds', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(maintenanceItemDTO);
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: maintenanceItemDTO });
         });
 
         it('calls executeQuery', async () => {
@@ -528,7 +528,7 @@ describe('equipment data', () => {
 
       describe('when the insert fails', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(null);
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'SERVER_ERROR' });
         });
 
         it('returns null', async () => {
@@ -577,7 +577,7 @@ describe('equipment data', () => {
     describe('when logged in', () => {
       beforeEach(() => {
         setLoggedIn();
-        (executeQuery as Mock).mockResolvedValue(null);
+        (executeQuery as Mock).mockResolvedValue({ success: true, data: null });
       });
 
       it('calls executeQuery', async () => {
@@ -615,7 +615,7 @@ describe('equipment data', () => {
 
       describe('when the update succeeds', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(maintenanceItemDTO);
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: maintenanceItemDTO });
         });
 
         it('calls executeQuery', async () => {
@@ -635,7 +635,7 @@ describe('equipment data', () => {
 
       describe('when the update fails', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(null);
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'SERVER_ERROR' });
         });
 
         it('returns null', async () => {
@@ -668,7 +668,7 @@ describe('equipment data', () => {
 
       describe('when data is returned', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue([maintenanceTypeDTO]);
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: [maintenanceTypeDTO] });
         });
 
         it('calls executeQuery', async () => {
@@ -688,9 +688,9 @@ describe('equipment data', () => {
         });
       });
 
-      describe('when no data is returned', () => {
+      describe('on error', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(null);
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'SERVER_ERROR' });
         });
 
         it('returns an empty array', async () => {
@@ -723,7 +723,7 @@ describe('equipment data', () => {
 
       describe('when data is returned', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue([usageUnitsDTO]);
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: [usageUnitsDTO] });
         });
 
         it('calls executeQuery', async () => {
@@ -741,9 +741,9 @@ describe('equipment data', () => {
         });
       });
 
-      describe('when no data is returned', () => {
+      describe('on error', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(null);
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'SERVER_ERROR' });
         });
 
         it('returns an empty array', async () => {

--- a/app/adventure/equipment/data.ts
+++ b/app/adventure/equipment/data.ts
@@ -94,22 +94,22 @@ const maintenanceItemUpdate = (supabase: SupabaseClient, item: MaintenanceItem):
     .single();
 
 export const fetchAllEquipment = async (): Promise<Equipment[]> => {
-  const { data } = await withAuth((supabase: SupabaseClient) => executeQuery<EquipmentDTO[]>(equipmentQuery(supabase)));
-  return (data || []).map((p) => convertToEquipment(p) as Equipment);
+  const res = await withAuth((supabase: SupabaseClient) => executeQuery<EquipmentDTO[]>(equipmentQuery(supabase)));
+  return (res.success ? res.data : []).map((p) => convertToEquipment(p) as Equipment);
 };
 
 export const fetchEquipment = async (id: number, full?: boolean): Promise<Equipment | null> => {
-  const { data } = await withAuth((supabase: SupabaseClient) =>
+  const res = await withAuth((supabase: SupabaseClient) =>
     executeQuery<EquipmentDTO>(full ? fullEquipmentQuery(supabase, id) : equipmentQuery(supabase, id)),
   );
-  return data ? (convertToEquipment(data) as Equipment) : null;
+  return res.success ? (convertToEquipment(res.data) as Equipment) : null;
 };
 
 export const addEquipment = async (equipment: Equipment): Promise<Equipment | null> => {
-  const { data } = await withAuth((supabase: SupabaseClient) =>
+  const res = await withAuth((supabase: SupabaseClient) =>
     executeQuery<EquipmentDTO>(equipmentInsert(supabase, equipment)),
   );
-  return data ? (convertToEquipment(data) as Equipment) : null;
+  return res.success ? (convertToEquipment(res.data) as Equipment) : null;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -124,31 +124,31 @@ export const deleteEquipment = async (equipment: Equipment): Promise<boolean> =>
 };
 
 export const updateEquipment = async (equipment: Equipment): Promise<Equipment | null> => {
-  const { data } = await withAuth((supabase: SupabaseClient) =>
+  const res = await withAuth((supabase: SupabaseClient) =>
     executeQuery<EquipmentDTO>(equipmentUpdate(supabase, equipment)),
   );
-  return data ? (convertToEquipment(data) as Equipment) : null;
+  return res.success ? (convertToEquipment(res.data) as Equipment) : null;
 };
 
 export const fetchEquipmentTypes = async (): Promise<EquipmentType[]> => {
-  const { data } = await withAuth((supabase: SupabaseClient) =>
+  const res = await withAuth((supabase: SupabaseClient) =>
     executeQuery<EquipmentTypeDTO[]>(equipmentTypesQuery(supabase)),
   );
-  return (data || []).map((p) => convertToEquipmentType(p) as EquipmentType);
+  return (res.success ? res.data : []).map((p) => convertToEquipmentType(p) as EquipmentType);
 };
 
 export const fetchMaintenanceItem = async (id: number): Promise<MaintenanceItem | null> => {
-  const { success, data } = await withAuth((supabase: SupabaseClient) =>
+  const res = await withAuth((supabase: SupabaseClient) =>
     executeQuery<MaintenanceItemDTO>(maintenanceItemQuery(supabase, id)),
   );
-  return success ? convertToMaintenance(data) : null;
+  return res.success ? convertToMaintenance(res.data) : null;
 };
 
 export const addMaintenanceItem = async (item: MaintenanceItem): Promise<MaintenanceItem | null> => {
-  const { data } = await withAuth((supabase: SupabaseClient) =>
+  const res = await withAuth((supabase: SupabaseClient) =>
     executeQuery<MaintenanceItemDTO>(maintenanceItemInsert(supabase, item)),
   );
-  return data ? convertToMaintenance(data) : null;
+  return res.success ? convertToMaintenance(res.data) : null;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -163,22 +163,20 @@ export const deleteMaintenanceItem = async (item: MaintenanceItem): Promise<bool
 };
 
 export const updateMaintenanceItem = async (item: MaintenanceItem): Promise<MaintenanceItem | null> => {
-  const { data } = await withAuth((supabase: SupabaseClient) =>
+  const res = await withAuth((supabase: SupabaseClient) =>
     executeQuery<MaintenanceItemDTO>(maintenanceItemUpdate(supabase, item)),
   );
-  return data ? convertToMaintenance(data) : null;
+  return res.success ? convertToMaintenance(res.data) : null;
 };
 
 export const fetchMaintenanceTypes = async (): Promise<MaintenanceType[]> => {
-  const { data } = await withAuth((supabase: SupabaseClient) =>
+  const res = await withAuth((supabase: SupabaseClient) =>
     executeQuery<MaintenanceTypeDTO[]>(maintenanceTypesQuery(supabase)),
   );
-  return (data || []).map((p) => convertToMaintenanceType(p) as MaintenanceType);
+  return (res.success ? res.data : []).map((p) => convertToMaintenanceType(p) as MaintenanceType);
 };
 
 export const fetchUsageUnits = async (): Promise<UsageUnits[]> => {
-  const { data } = await withAuth((supabase: SupabaseClient) =>
-    executeQuery<UsageUnitsDTO[]>(usageUnitsQuery(supabase)),
-  );
-  return (data || []).map((p) => convertToUsageUnits(p) as UsageUnits);
+  const res = await withAuth((supabase: SupabaseClient) => executeQuery<UsageUnitsDTO[]>(usageUnitsQuery(supabase)));
+  return (res.success ? res.data : []).map((p) => convertToUsageUnits(p) as UsageUnits);
 };

--- a/app/adventure/equipment/data.ts
+++ b/app/adventure/equipment/data.ts
@@ -118,8 +118,9 @@ export const canDeleteEquipment = async (equipment: Equipment): Promise<boolean>
   return success;
 };
 
-export const deleteEquipment = async (equipment: Equipment): Promise<void> => {
-  await withAuth((supabase: SupabaseClient) => executeQuery(equipmentDelete(supabase, equipment)));
+export const deleteEquipment = async (equipment: Equipment): Promise<boolean> => {
+  const { success } = await withAuth((supabase: SupabaseClient) => executeQuery(equipmentDelete(supabase, equipment)));
+  return success;
 };
 
 export const updateEquipment = async (equipment: Equipment): Promise<Equipment | null> => {
@@ -156,8 +157,9 @@ export const canDeleteMaintenanceItem = async (item: MaintenanceItem): Promise<b
   return success;
 };
 
-export const deleteMaintenanceItem = async (item: MaintenanceItem): Promise<void> => {
-  await withAuth((supabase: SupabaseClient) => executeQuery(maintenanceItemDelete(supabase, item)));
+export const deleteMaintenanceItem = async (item: MaintenanceItem): Promise<boolean> => {
+  const { success } = await withAuth((supabase: SupabaseClient) => executeQuery(maintenanceItemDelete(supabase, item)));
+  return success;
 };
 
 export const updateMaintenanceItem = async (item: MaintenanceItem): Promise<MaintenanceItem | null> => {

--- a/app/adventure/equipment/data.ts
+++ b/app/adventure/equipment/data.ts
@@ -94,19 +94,19 @@ const maintenanceItemUpdate = (supabase: SupabaseClient, item: MaintenanceItem):
     .single();
 
 export const fetchAllEquipment = async (): Promise<Equipment[]> => {
-  const data = await withAuth((supabase: SupabaseClient) => executeQuery<EquipmentDTO[]>(equipmentQuery(supabase)));
+  const { data } = await withAuth((supabase: SupabaseClient) => executeQuery<EquipmentDTO[]>(equipmentQuery(supabase)));
   return (data || []).map((p) => convertToEquipment(p) as Equipment);
 };
 
 export const fetchEquipment = async (id: number, full?: boolean): Promise<Equipment | null> => {
-  const data = await withAuth((supabase: SupabaseClient) =>
+  const { data } = await withAuth((supabase: SupabaseClient) =>
     executeQuery<EquipmentDTO>(full ? fullEquipmentQuery(supabase, id) : equipmentQuery(supabase, id)),
   );
   return data ? (convertToEquipment(data) as Equipment) : null;
 };
 
 export const addEquipment = async (equipment: Equipment): Promise<Equipment | null> => {
-  const data = await withAuth((supabase: SupabaseClient) =>
+  const { data } = await withAuth((supabase: SupabaseClient) =>
     executeQuery<EquipmentDTO>(equipmentInsert(supabase, equipment)),
   );
   return data ? (convertToEquipment(data) as Equipment) : null;
@@ -114,7 +114,8 @@ export const addEquipment = async (equipment: Equipment): Promise<Equipment | nu
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const canDeleteEquipment = async (equipment: Equipment): Promise<boolean> => {
-  return !!(await withAuth(async () => true));
+  const { success } = await withAuth(async () => ({ success: true, data: true }));
+  return success;
 };
 
 export const deleteEquipment = async (equipment: Equipment): Promise<void> => {
@@ -122,28 +123,28 @@ export const deleteEquipment = async (equipment: Equipment): Promise<void> => {
 };
 
 export const updateEquipment = async (equipment: Equipment): Promise<Equipment | null> => {
-  const data = await withAuth((supabase: SupabaseClient) =>
+  const { data } = await withAuth((supabase: SupabaseClient) =>
     executeQuery<EquipmentDTO>(equipmentUpdate(supabase, equipment)),
   );
   return data ? (convertToEquipment(data) as Equipment) : null;
 };
 
 export const fetchEquipmentTypes = async (): Promise<EquipmentType[]> => {
-  const data = await withAuth((supabase: SupabaseClient) =>
+  const { data } = await withAuth((supabase: SupabaseClient) =>
     executeQuery<EquipmentTypeDTO[]>(equipmentTypesQuery(supabase)),
   );
   return (data || []).map((p) => convertToEquipmentType(p) as EquipmentType);
 };
 
 export const fetchMaintenanceItem = async (id: number): Promise<MaintenanceItem | null> => {
-  const data = await withAuth((supabase: SupabaseClient) =>
+  const { success, data } = await withAuth((supabase: SupabaseClient) =>
     executeQuery<MaintenanceItemDTO>(maintenanceItemQuery(supabase, id)),
   );
-  return data && convertToMaintenance(data);
+  return success ? convertToMaintenance(data) : null;
 };
 
 export const addMaintenanceItem = async (item: MaintenanceItem): Promise<MaintenanceItem | null> => {
-  const data = await withAuth((supabase: SupabaseClient) =>
+  const { data } = await withAuth((supabase: SupabaseClient) =>
     executeQuery<MaintenanceItemDTO>(maintenanceItemInsert(supabase, item)),
   );
   return data ? convertToMaintenance(data) : null;
@@ -151,7 +152,8 @@ export const addMaintenanceItem = async (item: MaintenanceItem): Promise<Mainten
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const canDeleteMaintenanceItem = async (item: MaintenanceItem): Promise<boolean> => {
-  return !!(await withAuth(async () => true));
+  const { success } = await withAuth(async () => ({ success: true, data: true }));
+  return success;
 };
 
 export const deleteMaintenanceItem = async (item: MaintenanceItem): Promise<void> => {
@@ -159,20 +161,22 @@ export const deleteMaintenanceItem = async (item: MaintenanceItem): Promise<void
 };
 
 export const updateMaintenanceItem = async (item: MaintenanceItem): Promise<MaintenanceItem | null> => {
-  const data = await withAuth((supabase: SupabaseClient) =>
+  const { data } = await withAuth((supabase: SupabaseClient) =>
     executeQuery<MaintenanceItemDTO>(maintenanceItemUpdate(supabase, item)),
   );
   return data ? convertToMaintenance(data) : null;
 };
 
 export const fetchMaintenanceTypes = async (): Promise<MaintenanceType[]> => {
-  const data = await withAuth((supabase: SupabaseClient) =>
+  const { data } = await withAuth((supabase: SupabaseClient) =>
     executeQuery<MaintenanceTypeDTO[]>(maintenanceTypesQuery(supabase)),
   );
   return (data || []).map((p) => convertToMaintenanceType(p) as MaintenanceType);
 };
 
 export const fetchUsageUnits = async (): Promise<UsageUnits[]> => {
-  const data = await withAuth((supabase: SupabaseClient) => executeQuery<UsageUnitsDTO[]>(usageUnitsQuery(supabase)));
+  const { data } = await withAuth((supabase: SupabaseClient) =>
+    executeQuery<UsageUnitsDTO[]>(usageUnitsQuery(supabase)),
+  );
   return (data || []).map((p) => convertToUsageUnits(p) as UsageUnits);
 };

--- a/app/adventure/events/[id]/delete/__tests__/actions.spec.ts
+++ b/app/adventure/events/[id]/delete/__tests__/actions.spec.ts
@@ -1,6 +1,6 @@
 import { Event } from '@/models';
 import { EVENTS } from '@/app/adventure/events/__mocks__/data';
-import { describe, beforeEach, vi, it, expect } from 'vitest';
+import { describe, beforeEach, vi, it, expect, type Mock } from 'vitest';
 import { deleteAborted, deleteConfirmed } from '../actions';
 import { deleteEvent } from '@/app/adventure/events/data';
 import { redirect } from 'next/navigation';
@@ -15,50 +15,42 @@ describe('events: delete actions', () => {
 
   describe('deleteConfirmed', () => {
     it('calls deleteEvent', async () => {
-      await deleteConfirmed(event, 'Home');
+      await deleteConfirmed(event, 'Home').catch(() => {});
       expect(deleteEvent).toHaveBeenCalledExactlyOnceWith(event);
     });
 
     it.each([
-      {
-        page: 'Home',
-        expected: '/adventure',
-      },
-      {
-        page: 'Event',
-        expected: '/adventure/events',
-      },
-      {
-        page: 'Default',
-        expected: '/adventure/events',
-      },
-    ])('redirects to the $page page', async ({ page, expected }) => {
-      await deleteConfirmed(event, page);
+      { page: 'Home', expected: '/adventure' },
+      { page: 'Event', expected: '/adventure/events' },
+      { page: 'Default', expected: '/adventure/events' },
+    ])('redirects to the $page page if the delete succeeds', async ({ page, expected }) => {
+      (deleteEvent as Mock).mockResolvedValue(true);
+      await deleteConfirmed(event, page).catch(() => {});
       expect(redirect).toHaveBeenCalledExactlyOnceWith(expected);
     });
+
+    it.each([{ page: 'Home' }, { page: 'Event' }, { page: 'Default' }])(
+      'redirects to /error if the delete fails ($page)',
+      async ({ page }) => {
+        (deleteEvent as Mock).mockResolvedValue(false);
+        await deleteConfirmed(event, page).catch(() => {});
+        expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
+      },
+    );
   });
 
   describe('deleteAborted', () => {
     it('does not call deleteEvent', async () => {
-      await deleteAborted('Home');
+      await deleteAborted('Home').catch(() => {});
       expect(deleteEvent).not.toHaveBeenCalled();
     });
 
     it.each([
-      {
-        page: 'Home',
-        expected: '/adventure',
-      },
-      {
-        page: 'Event',
-        expected: '/adventure/events',
-      },
-      {
-        page: 'Default',
-        expected: '/adventure/events',
-      },
+      { page: 'Home', expected: '/adventure' },
+      { page: 'Event', expected: '/adventure/events' },
+      { page: 'Default', expected: '/adventure/events' },
     ])('redirects to the $page page', async ({ page, expected }) => {
-      await deleteAborted(page);
+      await deleteAborted(page).catch(() => {});
       expect(redirect).toHaveBeenCalledExactlyOnceWith(expected);
     });
   });

--- a/app/adventure/events/[id]/delete/actions.ts
+++ b/app/adventure/events/[id]/delete/actions.ts
@@ -6,8 +6,11 @@ import { deleteEvent } from '../../data';
 import { getHref } from '@/utils/get-href';
 
 export const deleteConfirmed = async (e: Event, callingPage: string) => {
-  await deleteEvent(e);
-  redirect(getHref(callingPage, '/adventure/events'));
+  if (await deleteEvent(e)) {
+    redirect(getHref(callingPage, '/adventure/events'));
+  } else {
+    redirect('/error');
+  }
 };
 
 export const deleteAborted = async (callingPage: string) => {

--- a/app/adventure/events/[id]/itinerary/[itineraryItemId]/delete/__tests__/actions.spec.ts
+++ b/app/adventure/events/[id]/itinerary/[itineraryItemId]/delete/__tests__/actions.spec.ts
@@ -1,7 +1,7 @@
 import { ItineraryItem } from '@/models';
 import { ITINERARY_ITEMS } from '@/app/adventure/events/[id]/itinerary/__mocks__/data';
 import { redirect } from 'next/navigation';
-import { describe, beforeEach, vi, it, expect } from 'vitest';
+import { describe, beforeEach, vi, it, expect, type Mock } from 'vitest';
 import { deleteConfirmed, deleteAborted } from '../actions';
 import { deleteItineraryItem } from '@/app/adventure/events/[id]/itinerary/data';
 
@@ -15,24 +15,31 @@ describe('itinerary item delete actions', () => {
 
   describe('deleteConfirmed', () => {
     it('calls deleteItineraryItem with the specified item', async () => {
-      await deleteConfirmed(103, itineraryItem);
+      await deleteConfirmed(103, itineraryItem).catch(() => {});
       expect(deleteItineraryItem).toHaveBeenCalledExactlyOnceWith(itineraryItem);
     });
 
-    it('redirects to the event details page', async () => {
-      await deleteConfirmed(103, itineraryItem);
+    it('redirects to the event details page if the delete succeeds', async () => {
+      (deleteItineraryItem as Mock).mockResolvedValue(true);
+      await deleteConfirmed(103, itineraryItem).catch(() => {});
       expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/events/103?lastActivity=Itinerary');
+    });
+
+    it('redirects to /error if the delete fails', async () => {
+      (deleteItineraryItem as Mock).mockResolvedValue(false);
+      await deleteConfirmed(103, itineraryItem).catch(() => {});
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
     });
   });
 
   describe('deleteAborted', () => {
     it('does not call deleteItineraryItem', async () => {
-      await deleteAborted(103);
+      await deleteAborted(103).catch(() => {});
       expect(deleteItineraryItem).not.toHaveBeenCalled();
     });
 
     it('redirects to the event details page', async () => {
-      await deleteAborted(103);
+      await deleteAborted(103).catch(() => {});
       expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/events/103?lastActivity=Itinerary');
     });
   });

--- a/app/adventure/events/[id]/itinerary/[itineraryItemId]/delete/actions.ts
+++ b/app/adventure/events/[id]/itinerary/[itineraryItemId]/delete/actions.ts
@@ -1,12 +1,16 @@
 'use server';
 
 import { ItineraryItem } from '@/models';
+import { redirect } from 'next/navigation';
 import { deleteItineraryItem } from '../../data';
 import { redirectToEventDetails } from '../../utils';
 
 export const deleteConfirmed = async (eventId: number, i: ItineraryItem) => {
-  await deleteItineraryItem(i);
-  redirectToEventDetails(eventId);
+  if (await deleteItineraryItem(i)) {
+    redirectToEventDetails(eventId);
+  } else {
+    redirect('/error');
+  }
 };
 
 export const deleteAborted = async (eventId: number) => {

--- a/app/adventure/events/[id]/itinerary/__mocks__/data.ts
+++ b/app/adventure/events/[id]/itinerary/__mocks__/data.ts
@@ -57,5 +57,5 @@ export const fetchItineraryItem = vi
   .mockImplementation((id: number) => Promise.resolve(ITINERARY_ITEMS.find((x) => x.id === id)));
 export const addItineraryItem = vi.fn();
 export const updateItineraryItem = vi.fn();
-export const deleteItineraryItem = vi.fn();
+export const deleteItineraryItem = vi.fn().mockResolvedValue(true);
 export const canDeleteItineraryItem = vi.fn().mockResolvedValue(false);

--- a/app/adventure/events/[id]/itinerary/__tests__/data.spec.ts
+++ b/app/adventure/events/[id]/itinerary/__tests__/data.spec.ts
@@ -71,7 +71,7 @@ describe('itinerary data', () => {
 
       describe('when data is returned', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(itineraryItemDTO);
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: itineraryItemDTO });
         });
 
         it('calls executeQuery', async () => {
@@ -91,7 +91,7 @@ describe('itinerary data', () => {
 
       describe('when no data is returned', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(null);
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'NOT_FOUND' });
         });
 
         it('returns null', async () => {
@@ -124,7 +124,7 @@ describe('itinerary data', () => {
 
       describe('when the insert succeeds', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(itineraryItemDTO);
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: itineraryItemDTO });
         });
 
         it('calls executeQuery', async () => {
@@ -144,7 +144,7 @@ describe('itinerary data', () => {
 
       describe('when the insert fails', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(null);
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'SERVER_ERROR' });
         });
 
         it('returns null', async () => {
@@ -193,7 +193,7 @@ describe('itinerary data', () => {
     describe('when logged in', () => {
       beforeEach(() => {
         setLoggedIn();
-        (executeQuery as Mock).mockResolvedValue(null);
+        (executeQuery as Mock).mockResolvedValue({ success: true, data: null });
       });
 
       it('calls executeQuery', async () => {
@@ -231,7 +231,7 @@ describe('itinerary data', () => {
 
       describe('when the update succeeds', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(itineraryItemDTO);
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: itineraryItemDTO });
         });
 
         it('calls executeQuery', async () => {
@@ -251,7 +251,7 @@ describe('itinerary data', () => {
 
       describe('when the update fails', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(null);
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'SERVER_ERROR' });
         });
 
         it('returns null', async () => {

--- a/app/adventure/events/[id]/itinerary/__tests__/data.spec.ts
+++ b/app/adventure/events/[id]/itinerary/__tests__/data.spec.ts
@@ -184,6 +184,10 @@ describe('itinerary data', () => {
     describe('when not logged in', () => {
       beforeEach(() => setLoggedOut());
 
+      it('returns false', async () => {
+        expect(await deleteItineraryItem(itineraryItem)).toBe(false);
+      });
+
       it('does not access the database', async () => {
         await deleteItineraryItem(itineraryItem);
         expect(executeQuery).not.toHaveBeenCalled();
@@ -191,19 +195,36 @@ describe('itinerary data', () => {
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        setLoggedIn();
-        (executeQuery as Mock).mockResolvedValue({ success: true, data: null });
+      describe('when the delete succeeds', () => {
+        beforeEach(() => {
+          setLoggedIn();
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: null });
+        });
+
+        it('calls executeQuery', async () => {
+          await deleteItineraryItem(itineraryItem);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('deletes from the itinerary_items table', async () => {
+          await deleteItineraryItem(itineraryItem);
+          expect(mockFrom).toHaveBeenCalledWith('itinerary_items');
+        });
+
+        it('returns true', async () => {
+          expect(await deleteItineraryItem(itineraryItem)).toBe(true);
+        });
       });
 
-      it('calls executeQuery', async () => {
-        await deleteItineraryItem(itineraryItem);
-        expect(executeQuery).toHaveBeenCalledOnce();
-      });
+      describe('when the delete fails', () => {
+        beforeEach(() => {
+          setLoggedIn();
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'SERVER_ERROR' });
+        });
 
-      it('deletes from the itinerary_items table', async () => {
-        await deleteItineraryItem(itineraryItem);
-        expect(mockFrom).toHaveBeenCalledWith('itinerary_items');
+        it('returns false', async () => {
+          expect(await deleteItineraryItem(itineraryItem)).toBe(false);
+        });
       });
     });
   });

--- a/app/adventure/events/[id]/itinerary/data.ts
+++ b/app/adventure/events/[id]/itinerary/data.ts
@@ -32,22 +32,23 @@ const itineraryItemDelete = (supabase: SupabaseClient, item: ItineraryItem): any
 };
 
 export const fetchItineraryItem = async (id: number): Promise<ItineraryItem | null> => {
-  const data = await withAuth((supabase: SupabaseClient) =>
+  const { success, data } = await withAuth((supabase: SupabaseClient) =>
     executeQuery<ItineraryItemDTO>(itineraryItemQuery(supabase, id)),
   );
-  return data ? convertToItineraryItem(data) : null;
+  return success ? convertToItineraryItem(data) : null;
 };
 
 export const addItineraryItem = async (item: ItineraryItem): Promise<ItineraryItem | null> => {
-  const data = await withAuth((supabase: SupabaseClient) =>
+  const { success, data } = await withAuth((supabase: SupabaseClient) =>
     executeQuery<ItineraryItemDTO>(itineraryItemInsert(supabase, item)),
   );
-  return data ? convertToItineraryItem(data) : null;
+  return success ? convertToItineraryItem(data) : null;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const canDeleteItineraryItem = async (item: ItineraryItem): Promise<boolean> => {
-  return !!(await withAuth(async () => true));
+  const { success } = await withAuth(async () => ({ success: true, data: true }));
+  return success;
 };
 
 export const deleteItineraryItem = async (item: ItineraryItem): Promise<void> => {
@@ -55,8 +56,8 @@ export const deleteItineraryItem = async (item: ItineraryItem): Promise<void> =>
 };
 
 export const updateItineraryItem = async (item: ItineraryItem): Promise<ItineraryItem | null> => {
-  const data = await withAuth((supabase: SupabaseClient) =>
+  const { success, data } = await withAuth((supabase: SupabaseClient) =>
     executeQuery<ItineraryItemDTO>(itineraryItemUpdate(supabase, item)),
   );
-  return data ? convertToItineraryItem(data) : null;
+  return success ? convertToItineraryItem(data) : null;
 };

--- a/app/adventure/events/[id]/itinerary/data.ts
+++ b/app/adventure/events/[id]/itinerary/data.ts
@@ -32,17 +32,17 @@ const itineraryItemDelete = (supabase: SupabaseClient, item: ItineraryItem): any
 };
 
 export const fetchItineraryItem = async (id: number): Promise<ItineraryItem | null> => {
-  const { success, data } = await withAuth((supabase: SupabaseClient) =>
+  const res = await withAuth((supabase: SupabaseClient) =>
     executeQuery<ItineraryItemDTO>(itineraryItemQuery(supabase, id)),
   );
-  return success ? convertToItineraryItem(data) : null;
+  return res.success ? convertToItineraryItem(res.data) : null;
 };
 
 export const addItineraryItem = async (item: ItineraryItem): Promise<ItineraryItem | null> => {
-  const { success, data } = await withAuth((supabase: SupabaseClient) =>
+  const res = await withAuth((supabase: SupabaseClient) =>
     executeQuery<ItineraryItemDTO>(itineraryItemInsert(supabase, item)),
   );
-  return success ? convertToItineraryItem(data) : null;
+  return res.success ? convertToItineraryItem(res.data) : null;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -59,8 +59,8 @@ export const deleteItineraryItem = async (item: ItineraryItem): Promise<boolean>
 };
 
 export const updateItineraryItem = async (item: ItineraryItem): Promise<ItineraryItem | null> => {
-  const { success, data } = await withAuth((supabase: SupabaseClient) =>
+  const res = await withAuth((supabase: SupabaseClient) =>
     executeQuery<ItineraryItemDTO>(itineraryItemUpdate(supabase, item)),
   );
-  return success ? convertToItineraryItem(data) : null;
+  return res.success ? convertToItineraryItem(res.data) : null;
 };

--- a/app/adventure/events/[id]/itinerary/data.ts
+++ b/app/adventure/events/[id]/itinerary/data.ts
@@ -53,7 +53,7 @@ export const canDeleteItineraryItem = async (item: ItineraryItem): Promise<boole
 
 export const deleteItineraryItem = async (item: ItineraryItem): Promise<boolean> => {
   const { success } = await withAuth((supabase: SupabaseClient) =>
-    executeQuery<void>(itineraryItemDelete(supabase, item)),
+    executeQuery<null>(itineraryItemDelete(supabase, item)),
   );
   return success;
 };

--- a/app/adventure/events/[id]/itinerary/data.ts
+++ b/app/adventure/events/[id]/itinerary/data.ts
@@ -51,8 +51,11 @@ export const canDeleteItineraryItem = async (item: ItineraryItem): Promise<boole
   return success;
 };
 
-export const deleteItineraryItem = async (item: ItineraryItem): Promise<void> => {
-  await withAuth((supabase: SupabaseClient) => executeQuery<void>(itineraryItemDelete(supabase, item)));
+export const deleteItineraryItem = async (item: ItineraryItem): Promise<boolean> => {
+  const { success } = await withAuth((supabase: SupabaseClient) =>
+    executeQuery<void>(itineraryItemDelete(supabase, item)),
+  );
+  return success;
 };
 
 export const updateItineraryItem = async (item: ItineraryItem): Promise<ItineraryItem | null> => {

--- a/app/adventure/events/[id]/notes/[noteId]/delete/__tests__/actions.spec.ts
+++ b/app/adventure/events/[id]/notes/[noteId]/delete/__tests__/actions.spec.ts
@@ -2,7 +2,7 @@ import { NOTES } from '@/app/adventure/notes/__mocks__/data';
 import { deleteNote } from '@/app/adventure/notes/data';
 import { Note } from '@/models';
 import { redirect } from 'next/navigation';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 import { deleteAborted, deleteConfirmed } from '../actions';
 
 vi.mock('@/app/adventure/notes/data');
@@ -15,24 +15,31 @@ describe('event notes: delete actions', () => {
 
   describe('deleteConfirmed', () => {
     it('calls deleteNote', async () => {
-      await deleteConfirmed(19, note);
+      await deleteConfirmed(19, note).catch(() => {});
       expect(deleteNote).toHaveBeenCalledExactlyOnceWith(note);
     });
 
-    it('redirects to the event details page', async () => {
-      await deleteConfirmed(19, note);
+    it('redirects to the event details page if the delete succeeds', async () => {
+      (deleteNote as Mock).mockResolvedValue(true);
+      await deleteConfirmed(19, note).catch(() => {});
       expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/events/19?lastActivity=Notes');
+    });
+
+    it('redirects to /error if the delete fails', async () => {
+      (deleteNote as Mock).mockResolvedValue(false);
+      await deleteConfirmed(19, note).catch(() => {});
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
     });
   });
 
   describe('deleteAborted', () => {
     it('does not call deleteNote', async () => {
-      await deleteAborted(19);
+      await deleteAborted(19).catch(() => {});
       expect(deleteNote).not.toHaveBeenCalled();
     });
 
     it('redirects to the event details page', async () => {
-      await deleteAborted(19);
+      await deleteAborted(19).catch(() => {});
       expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/events/19?lastActivity=Notes');
     });
   });

--- a/app/adventure/events/[id]/notes/[noteId]/delete/actions.ts
+++ b/app/adventure/events/[id]/notes/[noteId]/delete/actions.ts
@@ -2,11 +2,15 @@
 
 import { deleteNote } from '@/app/adventure/notes/data';
 import { Note } from '@/models';
+import { redirect } from 'next/navigation';
 import { redirectToEventDetails } from '../../utils';
 
 export const deleteConfirmed = async (eventId: number, n: Note) => {
-  await deleteNote(n);
-  redirectToEventDetails(eventId);
+  if (await deleteNote(n)) {
+    redirectToEventDetails(eventId);
+  } else {
+    redirect('/error');
+  }
 };
 
 export const deleteAborted = async (eventId: number) => {

--- a/app/adventure/events/[id]/todos/[collectionId]/delete/__tests__/actions.spec.ts
+++ b/app/adventure/events/[id]/todos/[collectionId]/delete/__tests__/actions.spec.ts
@@ -1,7 +1,7 @@
 import { TODO_COLLECTIONS } from '@/app/adventure/todos/__mocks__/data';
 import { TodoCollection } from '@/models';
 import { redirect } from 'next/navigation';
-import { describe, beforeEach, vi, it, expect } from 'vitest';
+import { describe, beforeEach, vi, it, expect, type Mock } from 'vitest';
 import { deleteConfirmed, deleteAborted } from '../actions';
 import { deleteTodoCollection } from '@/app/adventure/todos/data';
 
@@ -15,24 +15,31 @@ describe('event todos: delete actions', () => {
 
   describe('deleteConfirmed', () => {
     it('calls deleteTodoCollection', async () => {
-      await deleteConfirmed(324, todos);
+      await deleteConfirmed(324, todos).catch(() => {});
       expect(deleteTodoCollection).toHaveBeenCalledExactlyOnceWith(todos);
     });
 
-    it('redirects to the event details page', async () => {
-      await deleteConfirmed(324, todos);
+    it('redirects to the event details page if the delete succeeds', async () => {
+      (deleteTodoCollection as Mock).mockResolvedValue(true);
+      await deleteConfirmed(324, todos).catch(() => {});
       expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/events/324?lastActivity=Todos');
+    });
+
+    it('redirects to /error if the delete fails', async () => {
+      (deleteTodoCollection as Mock).mockResolvedValue(false);
+      await deleteConfirmed(324, todos).catch(() => {});
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
     });
   });
 
   describe('deleteAborted', () => {
     it('does not call deleteTodoCollection', async () => {
-      await deleteAborted(324);
+      await deleteAborted(324).catch(() => {});
       expect(deleteTodoCollection).not.toHaveBeenCalled();
     });
 
     it('redirects to the event details page', async () => {
-      await deleteAborted(324);
+      await deleteAborted(324).catch(() => {});
       expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/events/324?lastActivity=Todos');
     });
   });

--- a/app/adventure/events/[id]/todos/[collectionId]/delete/actions.ts
+++ b/app/adventure/events/[id]/todos/[collectionId]/delete/actions.ts
@@ -2,11 +2,15 @@
 
 import { deleteTodoCollection } from '@/app/adventure/todos/data';
 import { TodoCollection } from '@/models';
+import { redirect } from 'next/navigation';
 import { redirectToEventDetails } from '../../utils';
 
 export const deleteConfirmed = async (eventId: number, c: TodoCollection) => {
-  await deleteTodoCollection(c);
-  redirectToEventDetails(eventId);
+  if (await deleteTodoCollection(c)) {
+    redirectToEventDetails(eventId);
+  } else {
+    redirect('/error');
+  }
 };
 
 export const deleteAborted = async (eventId: number) => {

--- a/app/adventure/events/__mocks__/data.ts
+++ b/app/adventure/events/__mocks__/data.ts
@@ -70,7 +70,7 @@ export const fetchEvent = vi.fn().mockImplementation((id: number, full: boolean 
   return Promise.resolve(event && (full ? { ...event, notes: [], todoCollections: [] } : { ...event }));
 });
 export const addEvent = vi.fn();
-export const deleteEvent = vi.fn();
+export const deleteEvent = vi.fn().mockResolvedValue(true);
 export const canDeleteEvent = vi.fn().mockResolvedValue(false);
 export const fetchEventTypes = vi.fn().mockResolvedValue(EVENT_TYPES);
 export const updateEvent = vi.fn().mockResolvedValue(null);

--- a/app/adventure/events/__tests__/data.spec.ts
+++ b/app/adventure/events/__tests__/data.spec.ts
@@ -123,7 +123,7 @@ describe('events data', () => {
 
       describe('when data is returned', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue([eventDTO]);
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: [eventDTO] });
         });
 
         it('calls executeQuery', async () => {
@@ -148,7 +148,7 @@ describe('events data', () => {
 
       describe('when no data is returned', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(null);
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'NOT_FOUND' });
         });
 
         it('returns an empty array', async () => {
@@ -181,7 +181,7 @@ describe('events data', () => {
 
       describe('when data is returned', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue([eventDTO]);
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: [eventDTO] });
         });
 
         it('calls executeQuery', async () => {
@@ -201,7 +201,7 @@ describe('events data', () => {
 
       describe('when no data is returned', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(null);
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'NOT_FOUND' });
         });
 
         it('returns an empty array', async () => {
@@ -234,7 +234,7 @@ describe('events data', () => {
 
       describe('when data is returned', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue([eventDTO]);
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: [eventDTO] });
         });
 
         it('calls executeQuery', async () => {
@@ -254,7 +254,7 @@ describe('events data', () => {
 
       describe('when no data is returned', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(null);
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'NOT_FOUND' });
         });
 
         it('returns an empty array', async () => {
@@ -287,7 +287,7 @@ describe('events data', () => {
 
       describe('when data is returned', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(eventDTO);
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: eventDTO });
         });
 
         it('calls executeQuery', async () => {
@@ -318,7 +318,7 @@ describe('events data', () => {
 
       describe('when no data is returned', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(null);
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'NOT_FOUND' });
         });
 
         it('returns null', async () => {
@@ -351,7 +351,7 @@ describe('events data', () => {
 
       describe('when the insert succeeds', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(eventDTO);
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: eventDTO });
         });
 
         it('calls executeQuery', async () => {
@@ -371,7 +371,7 @@ describe('events data', () => {
 
       describe('when the insert fails', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(null);
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'SERVER_ERROR' });
         });
 
         it('returns null', async () => {
@@ -455,7 +455,7 @@ describe('events data', () => {
 
       describe('when data is returned', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue([eventTypeDTO]);
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: [eventTypeDTO] });
         });
 
         it('calls executeQuery', async () => {
@@ -475,7 +475,7 @@ describe('events data', () => {
 
       describe('when no data is returned', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(null);
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'SERVER_ERROR' });
         });
 
         it('returns an empty array', async () => {
@@ -508,7 +508,7 @@ describe('events data', () => {
 
       describe('when the update succeeds', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(eventDTO);
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: eventDTO });
         });
 
         it('calls executeQuery', async () => {
@@ -528,7 +528,7 @@ describe('events data', () => {
 
       describe('when the update fails', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(null);
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'SERVER_ERROR' });
         });
 
         it('returns null', async () => {

--- a/app/adventure/events/__tests__/data.spec.ts
+++ b/app/adventure/events/__tests__/data.spec.ts
@@ -411,6 +411,10 @@ describe('events data', () => {
     describe('when not logged in', () => {
       beforeEach(setLoggedOut);
 
+      it('returns false', async () => {
+        expect(await deleteEvent(event)).toBe(false);
+      });
+
       it('does not access the database', async () => {
         await deleteEvent(event);
         expect(executeQuery).not.toHaveBeenCalled();
@@ -418,16 +422,36 @@ describe('events data', () => {
     });
 
     describe('when logged in', () => {
-      beforeEach(setLoggedIn);
+      describe('when the delete succeeds', () => {
+        beforeEach(() => {
+          setLoggedIn();
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: null });
+        });
 
-      it('calls executeQuery', async () => {
-        await deleteEvent(event);
-        expect(executeQuery).toHaveBeenCalledOnce();
+        it('calls executeQuery', async () => {
+          await deleteEvent(event);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('deletes from the events table', async () => {
+          await deleteEvent(event);
+          expect(mockFrom).toHaveBeenCalledWith('events');
+        });
+
+        it('returns true', async () => {
+          expect(await deleteEvent(event)).toBe(true);
+        });
       });
 
-      it('deletes from the events table', async () => {
-        await deleteEvent(event);
-        expect(mockFrom).toHaveBeenCalledWith('events');
+      describe('when the delete fails', () => {
+        beforeEach(() => {
+          setLoggedIn();
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'SERVER_ERROR' });
+        });
+
+        it('returns false', async () => {
+          expect(await deleteEvent(event)).toBe(false);
+        });
       });
     });
   });

--- a/app/adventure/events/data.ts
+++ b/app/adventure/events/data.ts
@@ -105,7 +105,7 @@ export const canDeleteEvent = async (event: Event): Promise<boolean> => {
 };
 
 export const deleteEvent = async (event: Event): Promise<boolean> => {
-  const { success } = await withAuth((supabase: SupabaseClient) => executeQuery<void>(eventDelete(supabase, event)));
+  const { success } = await withAuth((supabase: SupabaseClient) => executeQuery<null>(eventDelete(supabase, event)));
   return success;
 };
 

--- a/app/adventure/events/data.ts
+++ b/app/adventure/events/data.ts
@@ -68,39 +68,44 @@ const eventTypesQuery = (supabase: SupabaseClient): any => {
 };
 
 export const fetchUpcomingEvents = async (startDate: string, endDate?: string): Promise<Event[]> => {
-  const data = await withAuth((supabase: SupabaseClient) =>
+  const { data } = await withAuth((supabase: SupabaseClient) =>
     executeQuery<EventDTO[]>(upcomingEventsQuery(supabase, startDate, endDate)),
   );
   return (data || []).map((p) => convertToEvent(p) as Event);
 };
 
 export const fetchPriorEvents = async (dt: string): Promise<Event[]> => {
-  const data = await withAuth((supabase: SupabaseClient) => executeQuery<EventDTO[]>(priorEventsQuery(supabase, dt)));
+  const { data } = await withAuth((supabase: SupabaseClient) =>
+    executeQuery<EventDTO[]>(priorEventsQuery(supabase, dt)),
+  );
   return (data || []).map((p) => convertToEvent(p) as Event);
 };
 
 export const fetchLatestEvents = async (count: number): Promise<Event[]> => {
-  const data = await withAuth((supabase: SupabaseClient) =>
+  const { data } = await withAuth((supabase: SupabaseClient) =>
     executeQuery<EventDTO[]>(lastCreatedEventsQuery(supabase, count)),
   );
   return (data || []).map((p) => convertToEvent(p) as Event);
 };
 
 export const fetchEvent = async (id: number, full: boolean = false): Promise<Event | null> => {
-  const data = await withAuth((supabase: SupabaseClient) =>
+  const { success, data } = await withAuth((supabase: SupabaseClient) =>
     executeQuery<EventDTO>(full ? fullEventQuery(supabase, id) : eventQuery(supabase, id)),
   );
-  return data ? (convertToEvent(data) as Event) : null;
+  return success ? (convertToEvent(data) as Event) : null;
 };
 
 export const addEvent = async (event: Event): Promise<Event | null> => {
-  const data = await withAuth((supabase: SupabaseClient) => executeQuery<EventDTO>(eventInsert(supabase, event)));
-  return data ? (convertToEvent(data) as Event) : null;
+  const { success, data } = await withAuth((supabase: SupabaseClient) =>
+    executeQuery<EventDTO>(eventInsert(supabase, event)),
+  );
+  return success ? (convertToEvent(data) as Event) : null;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const canDeleteEvent = async (event: Event): Promise<boolean> => {
-  return !!(await withAuth(async () => true));
+  const { success } = await withAuth(async () => ({ success: true, data: true }));
+  return success;
 };
 
 export const deleteEvent = async (event: Event): Promise<void> => {
@@ -108,11 +113,13 @@ export const deleteEvent = async (event: Event): Promise<void> => {
 };
 
 export const fetchEventTypes = async (): Promise<EventType[]> => {
-  const data = await withAuth((supabase: SupabaseClient) => executeQuery<EventType[]>(eventTypesQuery(supabase)));
+  const { data } = await withAuth((supabase: SupabaseClient) => executeQuery<EventType[]>(eventTypesQuery(supabase)));
   return data || [];
 };
 
 export const updateEvent = async (event: Event): Promise<Event | null> => {
-  const data = await withAuth((supabase: SupabaseClient) => executeQuery<EventDTO>(eventUpdate(supabase, event)));
-  return data ? (convertToEvent(data) as Event) : null;
+  const { success, data } = await withAuth((supabase: SupabaseClient) =>
+    executeQuery<EventDTO>(eventUpdate(supabase, event)),
+  );
+  return success ? (convertToEvent(data) as Event) : null;
 };

--- a/app/adventure/events/data.ts
+++ b/app/adventure/events/data.ts
@@ -108,8 +108,9 @@ export const canDeleteEvent = async (event: Event): Promise<boolean> => {
   return success;
 };
 
-export const deleteEvent = async (event: Event): Promise<void> => {
-  await withAuth((supabase: SupabaseClient) => executeQuery<void>(eventDelete(supabase, event)));
+export const deleteEvent = async (event: Event): Promise<boolean> => {
+  const { success } = await withAuth((supabase: SupabaseClient) => executeQuery<void>(eventDelete(supabase, event)));
+  return success;
 };
 
 export const fetchEventTypes = async (): Promise<EventType[]> => {

--- a/app/adventure/events/data.ts
+++ b/app/adventure/events/data.ts
@@ -68,38 +68,34 @@ const eventTypesQuery = (supabase: SupabaseClient): any => {
 };
 
 export const fetchUpcomingEvents = async (startDate: string, endDate?: string): Promise<Event[]> => {
-  const { data } = await withAuth((supabase: SupabaseClient) =>
+  const res = await withAuth((supabase: SupabaseClient) =>
     executeQuery<EventDTO[]>(upcomingEventsQuery(supabase, startDate, endDate)),
   );
-  return (data || []).map((p) => convertToEvent(p) as Event);
+  return (res.success ? res.data : []).map((p) => convertToEvent(p) as Event);
 };
 
 export const fetchPriorEvents = async (dt: string): Promise<Event[]> => {
-  const { data } = await withAuth((supabase: SupabaseClient) =>
-    executeQuery<EventDTO[]>(priorEventsQuery(supabase, dt)),
-  );
-  return (data || []).map((p) => convertToEvent(p) as Event);
+  const res = await withAuth((supabase: SupabaseClient) => executeQuery<EventDTO[]>(priorEventsQuery(supabase, dt)));
+  return (res.success ? res.data : []).map((p) => convertToEvent(p) as Event);
 };
 
 export const fetchLatestEvents = async (count: number): Promise<Event[]> => {
-  const { data } = await withAuth((supabase: SupabaseClient) =>
+  const res = await withAuth((supabase: SupabaseClient) =>
     executeQuery<EventDTO[]>(lastCreatedEventsQuery(supabase, count)),
   );
-  return (data || []).map((p) => convertToEvent(p) as Event);
+  return (res.success ? res.data : []).map((p) => convertToEvent(p) as Event);
 };
 
 export const fetchEvent = async (id: number, full: boolean = false): Promise<Event | null> => {
-  const { success, data } = await withAuth((supabase: SupabaseClient) =>
+  const res = await withAuth((supabase: SupabaseClient) =>
     executeQuery<EventDTO>(full ? fullEventQuery(supabase, id) : eventQuery(supabase, id)),
   );
-  return success ? (convertToEvent(data) as Event) : null;
+  return res.success ? (convertToEvent(res.data) as Event) : null;
 };
 
 export const addEvent = async (event: Event): Promise<Event | null> => {
-  const { success, data } = await withAuth((supabase: SupabaseClient) =>
-    executeQuery<EventDTO>(eventInsert(supabase, event)),
-  );
-  return success ? (convertToEvent(data) as Event) : null;
+  const res = await withAuth((supabase: SupabaseClient) => executeQuery<EventDTO>(eventInsert(supabase, event)));
+  return res.success ? (convertToEvent(res.data) as Event) : null;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -114,13 +110,11 @@ export const deleteEvent = async (event: Event): Promise<boolean> => {
 };
 
 export const fetchEventTypes = async (): Promise<EventType[]> => {
-  const { data } = await withAuth((supabase: SupabaseClient) => executeQuery<EventType[]>(eventTypesQuery(supabase)));
-  return data || [];
+  const res = await withAuth((supabase: SupabaseClient) => executeQuery<EventType[]>(eventTypesQuery(supabase)));
+  return res.success ? res.data : [];
 };
 
 export const updateEvent = async (event: Event): Promise<Event | null> => {
-  const { success, data } = await withAuth((supabase: SupabaseClient) =>
-    executeQuery<EventDTO>(eventUpdate(supabase, event)),
-  );
-  return success ? (convertToEvent(data) as Event) : null;
+  const res = await withAuth((supabase: SupabaseClient) => executeQuery<EventDTO>(eventUpdate(supabase, event)));
+  return res.success ? (convertToEvent(res.data) as Event) : null;
 };

--- a/app/adventure/notes/__mocks__/data.ts
+++ b/app/adventure/notes/__mocks__/data.ts
@@ -55,5 +55,5 @@ export const NOTES: Note[] = [
 export const fetchNote = vi.fn().mockImplementation((id: number) => Promise.resolve(NOTES.find((x) => x.id === id)));
 export const addNote = vi.fn();
 export const updateNote = vi.fn();
-export const deleteNote = vi.fn();
+export const deleteNote = vi.fn().mockResolvedValue(true);
 export const canDeleteNote = vi.fn().mockResolvedValue(false);

--- a/app/adventure/notes/__tests__/data.spec.ts
+++ b/app/adventure/notes/__tests__/data.spec.ts
@@ -65,7 +65,7 @@ describe('notes data', () => {
 
       describe('when data is returned', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(noteDTO);
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: noteDTO });
         });
 
         it('calls executeQuery', async () => {
@@ -85,7 +85,7 @@ describe('notes data', () => {
 
       describe('when no data is returned', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(null);
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'NOT_FOUND' });
         });
 
         it('returns null', async () => {
@@ -118,7 +118,7 @@ describe('notes data', () => {
 
       describe('when the insert succeeds', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(noteDTO);
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: noteDTO });
         });
 
         it('calls executeQuery', async () => {
@@ -138,7 +138,7 @@ describe('notes data', () => {
 
       describe('when the insert fails', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(null);
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'SERVER_ERROR' });
         });
 
         it('returns null', async () => {
@@ -187,7 +187,7 @@ describe('notes data', () => {
     describe('when logged in', () => {
       beforeEach(() => {
         setLoggedIn();
-        (executeQuery as Mock).mockResolvedValue(null);
+        (executeQuery as Mock).mockResolvedValue({ success: true, data: null });
       });
 
       it('calls executeQuery', async () => {
@@ -225,7 +225,7 @@ describe('notes data', () => {
 
       describe('when the update succeeds', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(noteDTO);
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: noteDTO });
         });
 
         it('calls executeQuery', async () => {
@@ -245,7 +245,7 @@ describe('notes data', () => {
 
       describe('when the update fails', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(null);
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'SERVER_ERROR' });
         });
 
         it('returns null', async () => {

--- a/app/adventure/notes/__tests__/data.spec.ts
+++ b/app/adventure/notes/__tests__/data.spec.ts
@@ -178,6 +178,10 @@ describe('notes data', () => {
     describe('when not logged in', () => {
       beforeEach(() => setLoggedOut());
 
+      it('returns false', async () => {
+        expect(await deleteNote(note)).toBe(false);
+      });
+
       it('does not access the database', async () => {
         await deleteNote(note);
         expect(executeQuery).not.toHaveBeenCalled();
@@ -185,19 +189,36 @@ describe('notes data', () => {
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        setLoggedIn();
-        (executeQuery as Mock).mockResolvedValue({ success: true, data: null });
+      describe('when the delete succeeds', () => {
+        beforeEach(() => {
+          setLoggedIn();
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: null });
+        });
+
+        it('calls executeQuery', async () => {
+          await deleteNote(note);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('deletes from the notes table', async () => {
+          await deleteNote(note);
+          expect(mockFrom).toHaveBeenCalledWith('notes');
+        });
+
+        it('returns true', async () => {
+          expect(await deleteNote(note)).toBe(true);
+        });
       });
 
-      it('calls executeQuery', async () => {
-        await deleteNote(note);
-        expect(executeQuery).toHaveBeenCalledOnce();
-      });
+      describe('when the delete fails', () => {
+        beforeEach(() => {
+          setLoggedIn();
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'SERVER_ERROR' });
+        });
 
-      it('deletes from the notes table', async () => {
-        await deleteNote(note);
-        expect(mockFrom).toHaveBeenCalledWith('notes');
+        it('returns false', async () => {
+          expect(await deleteNote(note)).toBe(false);
+        });
       });
     });
   });

--- a/app/adventure/notes/data.ts
+++ b/app/adventure/notes/data.ts
@@ -27,17 +27,13 @@ const noteDelete = (supabase: SupabaseClient, note: Note): any => {
 };
 
 export const fetchNote = async (id: number): Promise<Note | null> => {
-  const { success, data } = await withAuth((supabase: SupabaseClient) =>
-    executeQuery<NoteDTO>(noteQuery(supabase, id)),
-  );
-  return success ? convertToNote(data) : null;
+  const res = await withAuth((supabase: SupabaseClient) => executeQuery<NoteDTO>(noteQuery(supabase, id)));
+  return res.success ? convertToNote(res.data) : null;
 };
 
 export const addNote = async (note: Note): Promise<Note | null> => {
-  const { success, data } = await withAuth((supabase: SupabaseClient) =>
-    executeQuery<NoteDTO>(noteInsert(supabase, note)),
-  );
-  return success ? convertToNote(data) : null;
+  const res = await withAuth((supabase: SupabaseClient) => executeQuery<NoteDTO>(noteInsert(supabase, note)));
+  return res.success ? convertToNote(res.data) : null;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -52,8 +48,6 @@ export const deleteNote = async (note: Note): Promise<boolean> => {
 };
 
 export const updateNote = async (note: Note): Promise<Note | null> => {
-  const { success, data } = await withAuth((supabase: SupabaseClient) =>
-    executeQuery<NoteDTO>(noteUpdate(supabase, note)),
-  );
-  return success ? convertToNote(data) : null;
+  const res = await withAuth((supabase: SupabaseClient) => executeQuery<NoteDTO>(noteUpdate(supabase, note)));
+  return res.success ? convertToNote(res.data) : null;
 };

--- a/app/adventure/notes/data.ts
+++ b/app/adventure/notes/data.ts
@@ -43,7 +43,7 @@ export const canDeleteNote = async (note: Note): Promise<boolean> => {
 };
 
 export const deleteNote = async (note: Note): Promise<boolean> => {
-  const { success } = await withAuth((supabase: SupabaseClient) => executeQuery<void>(noteDelete(supabase, note)));
+  const { success } = await withAuth((supabase: SupabaseClient) => executeQuery<null>(noteDelete(supabase, note)));
   return success;
 };
 

--- a/app/adventure/notes/data.ts
+++ b/app/adventure/notes/data.ts
@@ -46,8 +46,9 @@ export const canDeleteNote = async (note: Note): Promise<boolean> => {
   return success;
 };
 
-export const deleteNote = async (note: Note): Promise<void> => {
-  await withAuth((supabase: SupabaseClient) => executeQuery<void>(noteDelete(supabase, note)));
+export const deleteNote = async (note: Note): Promise<boolean> => {
+  const { success } = await withAuth((supabase: SupabaseClient) => executeQuery<void>(noteDelete(supabase, note)));
+  return success;
 };
 
 export const updateNote = async (note: Note): Promise<Note | null> => {

--- a/app/adventure/notes/data.ts
+++ b/app/adventure/notes/data.ts
@@ -27,18 +27,23 @@ const noteDelete = (supabase: SupabaseClient, note: Note): any => {
 };
 
 export const fetchNote = async (id: number): Promise<Note | null> => {
-  const data = await withAuth((supabase: SupabaseClient) => executeQuery<NoteDTO>(noteQuery(supabase, id)));
-  return data ? convertToNote(data) : null;
+  const { success, data } = await withAuth((supabase: SupabaseClient) =>
+    executeQuery<NoteDTO>(noteQuery(supabase, id)),
+  );
+  return success ? convertToNote(data) : null;
 };
 
 export const addNote = async (note: Note): Promise<Note | null> => {
-  const data = await withAuth((supabase: SupabaseClient) => executeQuery<NoteDTO>(noteInsert(supabase, note)));
-  return data ? convertToNote(data) : null;
+  const { success, data } = await withAuth((supabase: SupabaseClient) =>
+    executeQuery<NoteDTO>(noteInsert(supabase, note)),
+  );
+  return success ? convertToNote(data) : null;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const canDeleteNote = async (note: Note): Promise<boolean> => {
-  return !!(await withAuth(async () => true));
+  const { success } = await withAuth(async () => ({ success: true, data: true }));
+  return success;
 };
 
 export const deleteNote = async (note: Note): Promise<void> => {
@@ -46,6 +51,8 @@ export const deleteNote = async (note: Note): Promise<void> => {
 };
 
 export const updateNote = async (note: Note): Promise<Note | null> => {
-  const data = await withAuth((supabase: SupabaseClient) => executeQuery<NoteDTO>(noteUpdate(supabase, note)));
-  return data ? convertToNote(data) : null;
+  const { success, data } = await withAuth((supabase: SupabaseClient) =>
+    executeQuery<NoteDTO>(noteUpdate(supabase, note)),
+  );
+  return success ? convertToNote(data) : null;
 };

--- a/app/adventure/places/[id]/delete/__tests__/actions.spec.ts
+++ b/app/adventure/places/[id]/delete/__tests__/actions.spec.ts
@@ -1,7 +1,7 @@
 import { Place } from '@/models';
 import { PLACES } from '@/app/adventure/places/__mocks__/data';
 import { redirect } from 'next/navigation';
-import { describe, beforeEach, vi, it, expect } from 'vitest';
+import { describe, beforeEach, vi, it, expect, type Mock } from 'vitest';
 import { deleteConfirmed, deleteAborted } from '../actions';
 import { deletePlace } from '@/app/adventure/places/data';
 
@@ -15,24 +15,31 @@ describe('places: delete actions', () => {
 
   describe('deleteConfirmed', () => {
     it('calls deletePlace', async () => {
-      await deleteConfirmed(place);
+      await deleteConfirmed(place).catch(() => {});
       expect(deletePlace).toHaveBeenCalledExactlyOnceWith(place);
     });
 
-    it('redirects to the places list page', async () => {
-      await deleteConfirmed(place);
+    it('redirects to the places list page if the delete succeeds', async () => {
+      (deletePlace as Mock).mockResolvedValue(true);
+      await deleteConfirmed(place).catch(() => {});
       expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/places');
+    });
+
+    it('redirects to /error if the delete fails', async () => {
+      (deletePlace as Mock).mockResolvedValue(false);
+      await deleteConfirmed(place).catch(() => {});
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
     });
   });
 
   describe('deleteAborted', () => {
     it('does not call deletePlace', async () => {
-      await deleteAborted();
+      await deleteAborted().catch(() => {});
       expect(deletePlace).not.toHaveBeenCalled();
     });
 
     it('redirects to the places list page', async () => {
-      await deleteAborted();
+      await deleteAborted().catch(() => {});
       expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/places');
     });
   });

--- a/app/adventure/places/[id]/delete/actions.ts
+++ b/app/adventure/places/[id]/delete/actions.ts
@@ -5,8 +5,11 @@ import { redirect } from 'next/navigation';
 import { deletePlace } from '../../data';
 
 export const deleteConfirmed = async (p: Place) => {
-  await deletePlace(p);
-  redirect('/adventure/places');
+  if (await deletePlace(p)) {
+    redirect('/adventure/places');
+  } else {
+    redirect('/error');
+  }
 };
 
 export const deleteAborted = async () => {

--- a/app/adventure/places/[id]/notes/[noteId]/delete/__tests__/actions.spec.ts
+++ b/app/adventure/places/[id]/notes/[noteId]/delete/__tests__/actions.spec.ts
@@ -1,7 +1,7 @@
 import { NOTES } from '@/app/adventure/notes/__mocks__/data';
 import { Note } from '@/models';
 import { redirect } from 'next/navigation';
-import { describe, beforeEach, vi, it, expect } from 'vitest';
+import { describe, beforeEach, vi, it, expect, type Mock } from 'vitest';
 import { deleteConfirmed, deleteAborted } from '../actions';
 import { deleteNote } from '@/app/adventure/notes/data';
 
@@ -15,24 +15,31 @@ describe('place notes: delete actions', () => {
 
   describe('deleteConfirmed', () => {
     it('calls deleteNote', async () => {
-      await deleteConfirmed(19, note);
+      await deleteConfirmed(19, note).catch(() => {});
       expect(deleteNote).toHaveBeenCalledExactlyOnceWith(note);
     });
 
-    it('redirects to the place details page', async () => {
-      await deleteConfirmed(19, note);
+    it('redirects to the place details page if the delete succeeds', async () => {
+      (deleteNote as Mock).mockResolvedValue(true);
+      await deleteConfirmed(19, note).catch(() => {});
       expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/places/19');
+    });
+
+    it('redirects to /error if the delete fails', async () => {
+      (deleteNote as Mock).mockResolvedValue(false);
+      await deleteConfirmed(19, note).catch(() => {});
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
     });
   });
 
   describe('deleteAborted', () => {
     it('does not call deleteNote', async () => {
-      await deleteAborted(19);
+      await deleteAborted(19).catch(() => {});
       expect(deleteNote).not.toHaveBeenCalled();
     });
 
     it('redirects to the place details page', async () => {
-      await deleteAborted(19);
+      await deleteAborted(19).catch(() => {});
       expect(redirect).toHaveBeenCalledExactlyOnceWith('/adventure/places/19');
     });
   });

--- a/app/adventure/places/[id]/notes/[noteId]/delete/actions.ts
+++ b/app/adventure/places/[id]/notes/[noteId]/delete/actions.ts
@@ -5,8 +5,11 @@ import { Note } from '@/models';
 import { redirect } from 'next/navigation';
 
 export const deleteConfirmed = async (placeId: number, n: Note) => {
-  await deleteNote(n);
-  redirect(`/adventure/places/${placeId}`);
+  if (await deleteNote(n)) {
+    redirect(`/adventure/places/${placeId}`);
+  } else {
+    redirect('/error');
+  }
 };
 
 export const deleteAborted = async (placeId: number) => {

--- a/app/adventure/places/__mocks__/data.ts
+++ b/app/adventure/places/__mocks__/data.ts
@@ -94,7 +94,7 @@ export const fetchPlace = vi.fn().mockImplementation((id: number, full?: boolean
 });
 export const addPlace = vi.fn();
 export const updatePlace = vi.fn();
-export const deletePlace = vi.fn();
+export const deletePlace = vi.fn().mockResolvedValue(true);
 export const canDeletePlace = vi.fn().mockResolvedValue(false);
 
 export const fetchPlaceTypes = vi.fn().mockResolvedValue(PLACE_TYPES);

--- a/app/adventure/places/__tests__/data.spec.ts
+++ b/app/adventure/places/__tests__/data.spec.ts
@@ -366,6 +366,10 @@ describe('places data', () => {
     describe('when not logged in', () => {
       beforeEach(() => setLoggedOut());
 
+      it('returns false', async () => {
+        expect(await deletePlace(place)).toBe(false);
+      });
+
       it('does not access the database', async () => {
         await deletePlace(place);
         expect(executeQuery).not.toHaveBeenCalled();
@@ -373,19 +377,36 @@ describe('places data', () => {
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        setLoggedIn();
-        (executeQuery as Mock).mockResolvedValue({ success: true, data: null });
+      describe('when the delete succeeds', () => {
+        beforeEach(() => {
+          setLoggedIn();
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: null });
+        });
+
+        it('calls executeQuery', async () => {
+          await deletePlace(place);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('deletes from the places table', async () => {
+          await deletePlace(place);
+          expect(mockFrom).toHaveBeenCalledWith('places');
+        });
+
+        it('returns true', async () => {
+          expect(await deletePlace(place)).toBe(true);
+        });
       });
 
-      it('calls executeQuery', async () => {
-        await deletePlace(place);
-        expect(executeQuery).toHaveBeenCalledOnce();
-      });
+      describe('when the delete fails', () => {
+        beforeEach(() => {
+          setLoggedIn();
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'SERVER_ERROR' });
+        });
 
-      it('deletes from the places table', async () => {
-        await deletePlace(place);
-        expect(mockFrom).toHaveBeenCalledWith('places');
+        it('returns false', async () => {
+          expect(await deletePlace(place)).toBe(false);
+        });
       });
     });
   });

--- a/app/adventure/places/__tests__/data.spec.ts
+++ b/app/adventure/places/__tests__/data.spec.ts
@@ -108,7 +108,7 @@ describe('places data', () => {
 
       describe('when data is returned', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue([placeDTO]);
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: [placeDTO] });
         });
 
         it('calls executeQuery', async () => {
@@ -128,7 +128,7 @@ describe('places data', () => {
 
       describe('when no data is returned', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(null);
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'NOT_FOUND' });
         });
 
         it('returns an empty array', async () => {
@@ -161,7 +161,9 @@ describe('places data', () => {
 
       describe('when data is returned', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(full ? placeWithNotesDTO : placeDTO);
+          (executeQuery as Mock).mockResolvedValue(
+            full ? { success: true, data: placeWithNotesDTO } : { success: true, data: placeDTO },
+          );
         });
 
         it('calls executeQuery', async () => {
@@ -181,7 +183,7 @@ describe('places data', () => {
 
       describe('when no data is returned', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(null);
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'NOT_FOUND' });
         });
 
         it('returns null', async () => {
@@ -214,7 +216,7 @@ describe('places data', () => {
 
       describe('when the insert succeeds', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(placeDTO);
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: placeDTO });
         });
 
         it('calls executeQuery', async () => {
@@ -234,7 +236,7 @@ describe('places data', () => {
 
       describe('when the insert fails', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(null);
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'SERVER_ERROR' });
         });
 
         it('returns null', async () => {
@@ -267,7 +269,7 @@ describe('places data', () => {
 
       describe('when data is returned', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue([placeTypeDTO]);
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: [placeTypeDTO] });
         });
 
         it('calls executeQuery', async () => {
@@ -287,7 +289,7 @@ describe('places data', () => {
 
       describe('when no data is returned', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(null);
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'SERVER_ERROR' });
         });
 
         it('returns an empty array', async () => {
@@ -319,14 +321,14 @@ describe('places data', () => {
       beforeEach(() => setLoggedIn());
 
       it('queries the events table', async () => {
-        (executeQuery as Mock).mockResolvedValue({ count: 0 });
+        (executeQuery as Mock).mockResolvedValue({ success: true, data: { count: 0 } });
         await canDeletePlace(place);
         expect(mockFrom).toHaveBeenCalledWith('events');
       });
 
       describe('when the place is not used in any events', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue({ count: 0 });
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: { count: 0 } });
         });
 
         it('returns true', async () => {
@@ -336,7 +338,7 @@ describe('places data', () => {
 
       describe('when the place is used in one or more events', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue({ count: 3 });
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: { count: 3 } });
         });
 
         it('returns false', async () => {
@@ -346,7 +348,7 @@ describe('places data', () => {
 
       describe('when the query returns no data', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(null);
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'SERVER_ERROR' });
         });
 
         it('returns false', async () => {
@@ -373,7 +375,7 @@ describe('places data', () => {
     describe('when logged in', () => {
       beforeEach(() => {
         setLoggedIn();
-        (executeQuery as Mock).mockResolvedValue(null);
+        (executeQuery as Mock).mockResolvedValue({ success: true, data: null });
       });
 
       it('calls executeQuery', async () => {
@@ -411,7 +413,7 @@ describe('places data', () => {
 
       describe('when the update succeeds', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(placeDTO);
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: placeDTO });
         });
 
         it('calls executeQuery', async () => {
@@ -431,7 +433,7 @@ describe('places data', () => {
 
       describe('when the update fails', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(null);
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'SERVER_ERROR' });
         });
 
         it('returns null', async () => {

--- a/app/adventure/places/data.ts
+++ b/app/adventure/places/data.ts
@@ -50,32 +50,32 @@ const placeTypesQuery = (supabase: SupabaseClient): any => {
 };
 
 export const fetchPlaces = async (): Promise<Place[]> => {
-  const data = await withAuth((supabase: SupabaseClient) => executeQuery<PlaceDTO[]>(placeQuery(supabase)));
+  const { data } = await withAuth((supabase: SupabaseClient) => executeQuery<PlaceDTO[]>(placeQuery(supabase)));
   return (data || []).map((p) => convertToPlace(p) as Place);
 };
 
 export const fetchPlace = async (id: number, full?: boolean): Promise<Place | null> => {
-  const data = await withAuth((supabase: SupabaseClient) =>
+  const { data } = await withAuth((supabase: SupabaseClient) =>
     executeQuery<PlaceDTO>(full ? fullPlaceQuery(supabase, id) : placeQuery(supabase, id)),
   );
   return data ? (convertToPlace(data) as Place) : null;
 };
 
 export const addPlace = async (place: Place): Promise<Place | null> => {
-  const data = await withAuth((supabase: SupabaseClient) => executeQuery<PlaceDTO>(placeInsert(supabase, place)));
+  const { data } = await withAuth((supabase: SupabaseClient) => executeQuery<PlaceDTO>(placeInsert(supabase, place)));
   return data ? (convertToPlace(data) as Place) : null;
 };
 
 export const fetchPlaceTypes = async (): Promise<PlaceType[]> => {
-  const data = await withAuth((supabase: SupabaseClient) => executeQuery<PlaceType[]>(placeTypesQuery(supabase)));
+  const { data } = await withAuth((supabase: SupabaseClient) => executeQuery<PlaceType[]>(placeTypesQuery(supabase)));
   return data || [];
 };
 
 export const canDeletePlace = async (place: Place): Promise<boolean> => {
-  const data = await withAuth((supabase: SupabaseClient) =>
+  const { data } = await withAuth((supabase: SupabaseClient) =>
     executeQuery<{ count: number }>(usageCountInEvents(supabase, place)),
   );
-  return data?.count === 0;
+  return !!(data?.count === 0);
 };
 
 export const deletePlace = async (place: Place): Promise<void> => {
@@ -83,6 +83,8 @@ export const deletePlace = async (place: Place): Promise<void> => {
 };
 
 export const updatePlace = async (place: Place): Promise<Place | null> => {
-  const data = await withAuth((supabase: SupabaseClient) => executeQuery<PlaceDTO>(placeUpdate(supabase, place)));
-  return data ? (convertToPlace(data) as Place) : null;
+  const { success, data } = await withAuth((supabase: SupabaseClient) =>
+    executeQuery<PlaceDTO>(placeUpdate(supabase, place)),
+  );
+  return success ? (convertToPlace(data) as Place) : null;
 };

--- a/app/adventure/places/data.ts
+++ b/app/adventure/places/data.ts
@@ -78,8 +78,9 @@ export const canDeletePlace = async (place: Place): Promise<boolean> => {
   return !!(data?.count === 0);
 };
 
-export const deletePlace = async (place: Place): Promise<void> => {
-  await withAuth((supabase: SupabaseClient) => executeQuery(placeDelete(supabase, place)));
+export const deletePlace = async (place: Place): Promise<boolean> => {
+  const { success } = await withAuth((supabase: SupabaseClient) => executeQuery(placeDelete(supabase, place)));
+  return success;
 };
 
 export const updatePlace = async (place: Place): Promise<Place | null> => {

--- a/app/adventure/places/data.ts
+++ b/app/adventure/places/data.ts
@@ -50,32 +50,32 @@ const placeTypesQuery = (supabase: SupabaseClient): any => {
 };
 
 export const fetchPlaces = async (): Promise<Place[]> => {
-  const { data } = await withAuth((supabase: SupabaseClient) => executeQuery<PlaceDTO[]>(placeQuery(supabase)));
-  return (data || []).map((p) => convertToPlace(p) as Place);
+  const res = await withAuth((supabase: SupabaseClient) => executeQuery<PlaceDTO[]>(placeQuery(supabase)));
+  return (res.success ? res.data : []).map((p) => convertToPlace(p) as Place);
 };
 
 export const fetchPlace = async (id: number, full?: boolean): Promise<Place | null> => {
-  const { data } = await withAuth((supabase: SupabaseClient) =>
+  const res = await withAuth((supabase: SupabaseClient) =>
     executeQuery<PlaceDTO>(full ? fullPlaceQuery(supabase, id) : placeQuery(supabase, id)),
   );
-  return data ? (convertToPlace(data) as Place) : null;
+  return res.success ? (convertToPlace(res.data) as Place) : null;
 };
 
 export const addPlace = async (place: Place): Promise<Place | null> => {
-  const { data } = await withAuth((supabase: SupabaseClient) => executeQuery<PlaceDTO>(placeInsert(supabase, place)));
-  return data ? (convertToPlace(data) as Place) : null;
+  const res = await withAuth((supabase: SupabaseClient) => executeQuery<PlaceDTO>(placeInsert(supabase, place)));
+  return res.success ? (convertToPlace(res.data) as Place) : null;
 };
 
 export const fetchPlaceTypes = async (): Promise<PlaceType[]> => {
-  const { data } = await withAuth((supabase: SupabaseClient) => executeQuery<PlaceType[]>(placeTypesQuery(supabase)));
-  return data || [];
+  const res = await withAuth((supabase: SupabaseClient) => executeQuery<PlaceType[]>(placeTypesQuery(supabase)));
+  return res.success ? res.data : [];
 };
 
 export const canDeletePlace = async (place: Place): Promise<boolean> => {
-  const { data } = await withAuth((supabase: SupabaseClient) =>
+  const res = await withAuth((supabase: SupabaseClient) =>
     executeQuery<{ count: number }>(usageCountInEvents(supabase, place)),
   );
-  return !!(data?.count === 0);
+  return !!(res.success ? res.data.count === 0 : false);
 };
 
 export const deletePlace = async (place: Place): Promise<boolean> => {
@@ -84,8 +84,6 @@ export const deletePlace = async (place: Place): Promise<boolean> => {
 };
 
 export const updatePlace = async (place: Place): Promise<Place | null> => {
-  const { success, data } = await withAuth((supabase: SupabaseClient) =>
-    executeQuery<PlaceDTO>(placeUpdate(supabase, place)),
-  );
-  return success ? (convertToPlace(data) as Place) : null;
+  const res = await withAuth((supabase: SupabaseClient) => executeQuery<PlaceDTO>(placeUpdate(supabase, place)));
+  return res.success ? (convertToPlace(res.data) as Place) : null;
 };

--- a/app/adventure/todos/[id]/delete/__tests__/actions.spec.ts
+++ b/app/adventure/todos/[id]/delete/__tests__/actions.spec.ts
@@ -2,7 +2,7 @@ import { TODO_COLLECTIONS } from '@/app/adventure/todos/__mocks__/data';
 import { deleteTodoCollection } from '@/app/adventure/todos/data';
 import { TodoCollection } from '@/models';
 import { redirect } from 'next/navigation';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 import { deleteAborted, deleteConfirmed } from '../actions';
 
 vi.mock('@/app/adventure/todos/data');
@@ -28,9 +28,16 @@ describe('todos: delete actions', () => {
       expect(deleteTodoCollection).toHaveBeenCalledExactlyOnceWith(todoCollection);
     });
 
-    it('redirects to /adventure/todos', async () => {
+    it('redirects to the correct page if the delete succeeds', async () => {
+      (deleteTodoCollection as Mock).mockResolvedValue(true);
       await deleteConfirmed(todoCollection, page).catch(() => {});
       expect(redirect).toHaveBeenCalledExactlyOnceWith(path);
+    });
+
+    it('redirects to /error if the delete fails', async () => {
+      (deleteTodoCollection as Mock).mockResolvedValue(false);
+      await deleteConfirmed(todoCollection, page).catch(() => {});
+      expect(redirect).toHaveBeenCalledExactlyOnceWith('/error');
     });
   });
 

--- a/app/adventure/todos/[id]/delete/actions.ts
+++ b/app/adventure/todos/[id]/delete/actions.ts
@@ -6,8 +6,11 @@ import { deleteTodoCollection } from '../../data';
 import { getHref } from '@/utils/get-href';
 
 export const deleteConfirmed = async (c: TodoCollection, callingPage: string) => {
-  await deleteTodoCollection(c);
-  redirect(getHref(callingPage, '/adventure/todos'));
+  if (await deleteTodoCollection(c)) {
+    redirect(getHref(callingPage, '/adventure/todos'));
+  } else {
+    redirect('/error');
+  }
 };
 
 export const deleteAborted = async (callingPage: string) => {

--- a/app/adventure/todos/__mocks__/data.ts
+++ b/app/adventure/todos/__mocks__/data.ts
@@ -92,9 +92,9 @@ export const fetchTodoCollection = vi
 export const fetchDueTodoCollections = vi.fn().mockResolvedValue(TODO_COLLECTIONS.filter((x) => !x.isComplete));
 export const addTodoCollection = vi.fn().mockResolvedValue(null);
 export const canDeleteTodoCollection = vi.fn().mockResolvedValue(false);
-export const deleteTodoCollection = vi.fn().mockResolvedValue(undefined);
+export const deleteTodoCollection = vi.fn().mockResolvedValue(true);
 export const updateTodoCollection = vi.fn().mockResolvedValue(null);
 export const addTodoItem = vi.fn().mockResolvedValue(null);
 export const canDeleteTodoItem = vi.fn().mockResolvedValue(false);
-export const deleteTodoItem = vi.fn().mockResolvedValue(undefined);
+export const deleteTodoItem = vi.fn().mockResolvedValue(true);
 export const updateTodoItem = vi.fn().mockResolvedValue(null);

--- a/app/adventure/todos/__tests__/data.spec.ts
+++ b/app/adventure/todos/__tests__/data.spec.ts
@@ -107,7 +107,7 @@ describe('todos data', () => {
 
       describe('when data is returned', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue([todoCollectionDTO]);
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: [todoCollectionDTO] });
         });
 
         it('calls executeQuery', async () => {
@@ -125,14 +125,14 @@ describe('todos data', () => {
         });
 
         it('converts nested todo items', async () => {
-          (executeQuery as Mock).mockResolvedValueOnce([todoCollectionDTOWithItems]);
+          (executeQuery as Mock).mockResolvedValueOnce({ success: true, data: [todoCollectionDTOWithItems] });
           expect(await fetchTodoCollections()).toEqual([todoCollectionWithItems]);
         });
       });
 
       describe('when no data is returned', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(null);
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'NOT_FOUND' });
         });
 
         it('returns an empty array', async () => {
@@ -165,7 +165,7 @@ describe('todos data', () => {
 
       describe('when data is returned', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(todoCollectionDTO);
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: todoCollectionDTO });
         });
 
         it('calls executeQuery', async () => {
@@ -183,14 +183,14 @@ describe('todos data', () => {
         });
 
         it('converts nested todo items', async () => {
-          (executeQuery as Mock).mockResolvedValueOnce(todoCollectionDTOWithItems);
+          (executeQuery as Mock).mockResolvedValueOnce({ success: true, data: todoCollectionDTOWithItems });
           expect(await fetchTodoCollection(1)).toEqual(todoCollectionWithItems);
         });
       });
 
       describe('when no data is returned', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(null);
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'NOT_FOUND' });
         });
 
         it('returns null', async () => {
@@ -223,7 +223,7 @@ describe('todos data', () => {
 
       describe('when data is returned', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue([todoCollectionDTO]);
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: [todoCollectionDTO] });
         });
 
         it('calls executeQuery', async () => {
@@ -243,7 +243,7 @@ describe('todos data', () => {
 
       describe('when no data is returned', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(null);
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'NOT_FOUND' });
         });
 
         it('returns an empty array', async () => {
@@ -276,7 +276,7 @@ describe('todos data', () => {
 
       describe('when the insert succeeds', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(todoCollectionDTO);
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: todoCollectionDTO });
         });
 
         it('calls executeQuery', async () => {
@@ -296,7 +296,7 @@ describe('todos data', () => {
 
       describe('when the insert fails', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(null);
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'SERVER_ERROR' });
         });
 
         it('returns null', async () => {
@@ -345,7 +345,7 @@ describe('todos data', () => {
     describe('when logged in', () => {
       beforeEach(() => {
         setLoggedIn();
-        (executeQuery as Mock).mockResolvedValue(null);
+        (executeQuery as Mock).mockResolvedValue({ success: true, data: null });
       });
 
       it('calls executeQuery', async () => {
@@ -383,7 +383,7 @@ describe('todos data', () => {
 
       describe('when the update succeeds', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(todoCollectionDTO);
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: todoCollectionDTO });
         });
 
         it('calls executeQuery', async () => {
@@ -403,7 +403,7 @@ describe('todos data', () => {
 
       describe('when the update fails', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(null);
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'SERVER_ERROR' });
         });
 
         it('returns null', async () => {
@@ -436,7 +436,7 @@ describe('todos data', () => {
 
       describe('when the insert succeeds', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(todoItemDTO);
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: todoItemDTO });
         });
 
         it('calls executeQuery', async () => {
@@ -456,7 +456,7 @@ describe('todos data', () => {
 
       describe('when the insert fails', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(null);
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'SERVER_ERROR' });
         });
 
         it('returns null', async () => {
@@ -505,7 +505,7 @@ describe('todos data', () => {
     describe('when logged in', () => {
       beforeEach(() => {
         setLoggedIn();
-        (executeQuery as Mock).mockResolvedValue(null);
+        (executeQuery as Mock).mockResolvedValue({ success: true, data: null });
       });
 
       it('calls executeQuery', async () => {
@@ -543,7 +543,7 @@ describe('todos data', () => {
 
       describe('when the update succeeds', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(todoItemDTO);
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: todoItemDTO });
         });
 
         it('calls executeQuery', async () => {
@@ -563,7 +563,7 @@ describe('todos data', () => {
 
       describe('when the update fails', () => {
         beforeEach(() => {
-          (executeQuery as Mock).mockResolvedValue(null);
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'SERVER_ERROR' });
         });
 
         it('returns null', async () => {

--- a/app/adventure/todos/__tests__/data.spec.ts
+++ b/app/adventure/todos/__tests__/data.spec.ts
@@ -336,6 +336,10 @@ describe('todos data', () => {
     describe('when not logged in', () => {
       beforeEach(() => setLoggedOut());
 
+      it('returns false', async () => {
+        expect(await deleteTodoCollection(todoCollection)).toBe(false);
+      });
+
       it('does not access the database', async () => {
         await deleteTodoCollection(todoCollection);
         expect(executeQuery).not.toHaveBeenCalled();
@@ -343,19 +347,36 @@ describe('todos data', () => {
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        setLoggedIn();
-        (executeQuery as Mock).mockResolvedValue({ success: true, data: null });
+      describe('when the delete succeeds', () => {
+        beforeEach(() => {
+          setLoggedIn();
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: null });
+        });
+
+        it('calls executeQuery', async () => {
+          await deleteTodoCollection(todoCollection);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('deletes from the todo_collections table', async () => {
+          await deleteTodoCollection(todoCollection);
+          expect(mockFrom).toHaveBeenCalledWith('todo_collections');
+        });
+
+        it('returns true', async () => {
+          expect(await deleteTodoCollection(todoCollection)).toBe(true);
+        });
       });
 
-      it('calls executeQuery', async () => {
-        await deleteTodoCollection(todoCollection);
-        expect(executeQuery).toHaveBeenCalledOnce();
-      });
+      describe('when the delete fails', () => {
+        beforeEach(() => {
+          setLoggedIn();
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'SERVER_ERROR' });
+        });
 
-      it('deletes from the todo_collections table', async () => {
-        await deleteTodoCollection(todoCollection);
-        expect(mockFrom).toHaveBeenCalledWith('todo_collections');
+        it('returns false', async () => {
+          expect(await deleteTodoCollection(todoCollection)).toBe(false);
+        });
       });
     });
   });
@@ -496,6 +517,10 @@ describe('todos data', () => {
     describe('when not logged in', () => {
       beforeEach(() => setLoggedOut());
 
+      it('returns false', async () => {
+        expect(await deleteTodoItem(todoItem)).toBe(false);
+      });
+
       it('does not access the database', async () => {
         await deleteTodoItem(todoItem);
         expect(executeQuery).not.toHaveBeenCalled();
@@ -503,19 +528,36 @@ describe('todos data', () => {
     });
 
     describe('when logged in', () => {
-      beforeEach(() => {
-        setLoggedIn();
-        (executeQuery as Mock).mockResolvedValue({ success: true, data: null });
+      describe('when the delete succeeds', () => {
+        beforeEach(() => {
+          setLoggedIn();
+          (executeQuery as Mock).mockResolvedValue({ success: true, data: null });
+        });
+
+        it('calls executeQuery', async () => {
+          await deleteTodoItem(todoItem);
+          expect(executeQuery).toHaveBeenCalledOnce();
+        });
+
+        it('deletes from the todo_items table', async () => {
+          await deleteTodoItem(todoItem);
+          expect(mockFrom).toHaveBeenCalledWith('todo_items');
+        });
+
+        it('returns true', async () => {
+          expect(await deleteTodoItem(todoItem)).toBe(true);
+        });
       });
 
-      it('calls executeQuery', async () => {
-        await deleteTodoItem(todoItem);
-        expect(executeQuery).toHaveBeenCalledOnce();
-      });
+      describe('when the delete fails', () => {
+        beforeEach(() => {
+          setLoggedIn();
+          (executeQuery as Mock).mockResolvedValue({ success: false, error: 'SERVER_ERROR' });
+        });
 
-      it('deletes from the todo_items table', async () => {
-        await deleteTodoItem(todoItem);
-        expect(mockFrom).toHaveBeenCalledWith('todo_items');
+        it('returns false', async () => {
+          expect(await deleteTodoItem(todoItem)).toBe(false);
+        });
       });
     });
   });

--- a/app/adventure/todos/data.ts
+++ b/app/adventure/todos/data.ts
@@ -102,7 +102,7 @@ export const canDeleteTodoCollection = async (collection: TodoCollection): Promi
 
 export const deleteTodoCollection = async (collection: TodoCollection): Promise<boolean> => {
   const { success } = await withAuth((supabase: SupabaseClient) =>
-    executeQuery<void>(todoCollectionDelete(supabase, collection)),
+    executeQuery<null>(todoCollectionDelete(supabase, collection)),
   );
   return success;
 };
@@ -126,7 +126,7 @@ export const canDeleteTodoItem = async (item: TodoItem): Promise<boolean> => {
 };
 
 export const deleteTodoItem = async (item: TodoItem): Promise<boolean> => {
-  const { success } = await withAuth((supabase: SupabaseClient) => executeQuery<void>(todoItemDelete(supabase, item)));
+  const { success } = await withAuth((supabase: SupabaseClient) => executeQuery<null>(todoItemDelete(supabase, item)));
   return success;
 };
 

--- a/app/adventure/todos/data.ts
+++ b/app/adventure/todos/data.ts
@@ -67,31 +67,31 @@ const todoItemDelete = (supabase: SupabaseClient, item: TodoItem): any =>
   supabase.from(itemTable).delete().eq('id', item.id);
 
 export const fetchTodoCollections = async (): Promise<TodoCollection[]> => {
-  const { data } = await withAuth((supabase: SupabaseClient) =>
+  const res = await withAuth((supabase: SupabaseClient) =>
     executeQuery<TodoCollectionDTO[]>(todoCollectionQuery(supabase)),
   );
-  return (data || []).map((p) => convertToTodoCollection(p) as TodoCollection);
+  return (res.success ? res.data : []).map((p) => convertToTodoCollection(p) as TodoCollection);
 };
 
 export const fetchTodoCollection = async (id: number): Promise<TodoCollection | null> => {
-  const { success, data } = await withAuth((supabase: SupabaseClient) =>
+  const res = await withAuth((supabase: SupabaseClient) =>
     executeQuery<TodoCollectionDTO>(todoCollectionQuery(supabase, id)),
   );
-  return success ? (convertToTodoCollection(data) as TodoCollection) : null;
+  return res.success ? (convertToTodoCollection(res.data) as TodoCollection) : null;
 };
 
 export const fetchDueTodoCollections = async (dueDate: string): Promise<TodoCollection[]> => {
-  const { data } = await withAuth((supabase: SupabaseClient) =>
+  const res = await withAuth((supabase: SupabaseClient) =>
     executeQuery<TodoCollectionDTO[]>(dueTodoCollectionQuery(supabase, dueDate)),
   );
-  return (data || []).map((p) => convertToTodoCollection(p) as TodoCollection);
+  return (res.success ? res.data : []).map((p) => convertToTodoCollection(p) as TodoCollection);
 };
 
 export const addTodoCollection = async (collection: TodoCollection): Promise<TodoCollection | null> => {
-  const { success, data } = await withAuth((supabase: SupabaseClient) =>
+  const res = await withAuth((supabase: SupabaseClient) =>
     executeQuery<TodoCollectionDTO>(todoCollectionInsert(supabase, collection)),
   );
-  return success ? (convertToTodoCollection(data) as TodoCollection) : null;
+  return res.success ? (convertToTodoCollection(res.data) as TodoCollection) : null;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -108,17 +108,15 @@ export const deleteTodoCollection = async (collection: TodoCollection): Promise<
 };
 
 export const updateTodoCollection = async (collection: TodoCollection): Promise<TodoCollection | null> => {
-  const { success, data } = await withAuth((supabase: SupabaseClient) =>
+  const res = await withAuth((supabase: SupabaseClient) =>
     executeQuery<TodoCollectionDTO>(todoCollectionUpdate(supabase, collection)),
   );
-  return success ? (convertToTodoCollection(data) as TodoCollection) : null;
+  return res.success ? (convertToTodoCollection(res.data) as TodoCollection) : null;
 };
 
 export const addTodoItem = async (item: TodoItem): Promise<TodoItem | null> => {
-  const { success, data } = await withAuth((supabase: SupabaseClient) =>
-    executeQuery<TodoItemDTO>(todoItemInsert(supabase, item)),
-  );
-  return success ? (convertToTodoItem(data) as TodoItem) : null;
+  const res = await withAuth((supabase: SupabaseClient) => executeQuery<TodoItemDTO>(todoItemInsert(supabase, item)));
+  return res.success ? (convertToTodoItem(res.data) as TodoItem) : null;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -133,8 +131,6 @@ export const deleteTodoItem = async (item: TodoItem): Promise<boolean> => {
 };
 
 export const updateTodoItem = async (item: TodoItem): Promise<TodoItem | null> => {
-  const { success, data } = await withAuth((supabase: SupabaseClient) =>
-    executeQuery<TodoItemDTO>(todoItemUpdate(supabase, item)),
-  );
-  return success ? (convertToTodoItem(data) as TodoItem) : null;
+  const res = await withAuth((supabase: SupabaseClient) => executeQuery<TodoItemDTO>(todoItemUpdate(supabase, item)));
+  return res.success ? (convertToTodoItem(res.data) as TodoItem) : null;
 };

--- a/app/adventure/todos/data.ts
+++ b/app/adventure/todos/data.ts
@@ -67,36 +67,37 @@ const todoItemDelete = (supabase: SupabaseClient, item: TodoItem): any =>
   supabase.from(itemTable).delete().eq('id', item.id);
 
 export const fetchTodoCollections = async (): Promise<TodoCollection[]> => {
-  const data = await withAuth((supabase: SupabaseClient) =>
+  const { data } = await withAuth((supabase: SupabaseClient) =>
     executeQuery<TodoCollectionDTO[]>(todoCollectionQuery(supabase)),
   );
   return (data || []).map((p) => convertToTodoCollection(p) as TodoCollection);
 };
 
 export const fetchTodoCollection = async (id: number): Promise<TodoCollection | null> => {
-  const data = await withAuth((supabase: SupabaseClient) =>
+  const { success, data } = await withAuth((supabase: SupabaseClient) =>
     executeQuery<TodoCollectionDTO>(todoCollectionQuery(supabase, id)),
   );
-  return data && (convertToTodoCollection(data) as TodoCollection);
+  return success ? (convertToTodoCollection(data) as TodoCollection) : null;
 };
 
 export const fetchDueTodoCollections = async (dueDate: string): Promise<TodoCollection[]> => {
-  const data = await withAuth((supabase: SupabaseClient) =>
+  const { data } = await withAuth((supabase: SupabaseClient) =>
     executeQuery<TodoCollectionDTO[]>(dueTodoCollectionQuery(supabase, dueDate)),
   );
   return (data || []).map((p) => convertToTodoCollection(p) as TodoCollection);
 };
 
 export const addTodoCollection = async (collection: TodoCollection): Promise<TodoCollection | null> => {
-  const data = await withAuth((supabase: SupabaseClient) =>
+  const { success, data } = await withAuth((supabase: SupabaseClient) =>
     executeQuery<TodoCollectionDTO>(todoCollectionInsert(supabase, collection)),
   );
-  return data && (convertToTodoCollection(data) as TodoCollection);
+  return success ? (convertToTodoCollection(data) as TodoCollection) : null;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const canDeleteTodoCollection = async (collection: TodoCollection): Promise<boolean> => {
-  return !!(await withAuth(async () => true));
+  const { success } = await withAuth(async () => ({ success: true, data: true }));
+  return success;
 };
 
 export const deleteTodoCollection = async (collection: TodoCollection): Promise<void> => {
@@ -104,20 +105,23 @@ export const deleteTodoCollection = async (collection: TodoCollection): Promise<
 };
 
 export const updateTodoCollection = async (collection: TodoCollection): Promise<TodoCollection | null> => {
-  const data = await withAuth((supabase: SupabaseClient) =>
+  const { success, data } = await withAuth((supabase: SupabaseClient) =>
     executeQuery<TodoCollectionDTO>(todoCollectionUpdate(supabase, collection)),
   );
-  return data && (convertToTodoCollection(data) as TodoCollection);
+  return success ? (convertToTodoCollection(data) as TodoCollection) : null;
 };
 
 export const addTodoItem = async (item: TodoItem): Promise<TodoItem | null> => {
-  const data = await withAuth((supabase: SupabaseClient) => executeQuery<TodoItemDTO>(todoItemInsert(supabase, item)));
-  return data && (convertToTodoItem(data) as TodoItem);
+  const { success, data } = await withAuth((supabase: SupabaseClient) =>
+    executeQuery<TodoItemDTO>(todoItemInsert(supabase, item)),
+  );
+  return success ? (convertToTodoItem(data) as TodoItem) : null;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const canDeleteTodoItem = async (item: TodoItem): Promise<boolean> => {
-  return !!(await withAuth(async () => true));
+  const { success } = await withAuth(async () => ({ success: true, data: true }));
+  return success;
 };
 
 export const deleteTodoItem = async (item: TodoItem): Promise<void> => {
@@ -125,6 +129,8 @@ export const deleteTodoItem = async (item: TodoItem): Promise<void> => {
 };
 
 export const updateTodoItem = async (item: TodoItem): Promise<TodoItem | null> => {
-  const data = await withAuth((supabase: SupabaseClient) => executeQuery<TodoItemDTO>(todoItemUpdate(supabase, item)));
-  return data && (convertToTodoItem(data) as TodoItem);
+  const { success, data } = await withAuth((supabase: SupabaseClient) =>
+    executeQuery<TodoItemDTO>(todoItemUpdate(supabase, item)),
+  );
+  return success ? (convertToTodoItem(data) as TodoItem) : null;
 };

--- a/app/adventure/todos/data.ts
+++ b/app/adventure/todos/data.ts
@@ -100,8 +100,11 @@ export const canDeleteTodoCollection = async (collection: TodoCollection): Promi
   return success;
 };
 
-export const deleteTodoCollection = async (collection: TodoCollection): Promise<void> => {
-  await withAuth((supabase: SupabaseClient) => executeQuery<void>(todoCollectionDelete(supabase, collection)));
+export const deleteTodoCollection = async (collection: TodoCollection): Promise<boolean> => {
+  const { success } = await withAuth((supabase: SupabaseClient) =>
+    executeQuery<void>(todoCollectionDelete(supabase, collection)),
+  );
+  return success;
 };
 
 export const updateTodoCollection = async (collection: TodoCollection): Promise<TodoCollection | null> => {
@@ -124,8 +127,9 @@ export const canDeleteTodoItem = async (item: TodoItem): Promise<boolean> => {
   return success;
 };
 
-export const deleteTodoItem = async (item: TodoItem): Promise<void> => {
-  await withAuth((supabase: SupabaseClient) => executeQuery<void>(todoItemDelete(supabase, item)));
+export const deleteTodoItem = async (item: TodoItem): Promise<boolean> => {
+  const { success } = await withAuth((supabase: SupabaseClient) => executeQuery<void>(todoItemDelete(supabase, item)));
+  return success;
 };
 
 export const updateTodoItem = async (item: TodoItem): Promise<TodoItem | null> => {

--- a/utils/data.ts
+++ b/utils/data.ts
@@ -1,6 +1,6 @@
 export type QueryResult<T> =
   | { success: true; data: T }
-  | { success: false; error: 'NOT_FOUND' | 'NOT_AUTHENTICATED' | 'SERVER_ERROR'; data?: never };
+  | { success: false; error: 'NOT_FOUND' | 'NOT_AUTHENTICATED' | 'SERVER_ERROR' };
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const performQuery = async <T>(query: any): Promise<QueryResult<T>> => {

--- a/utils/data.ts
+++ b/utils/data.ts
@@ -1,18 +1,22 @@
+export type QueryResult<T> =
+  | { success: true; data: T }
+  | { success: false; error: 'NOT_FOUND' | 'NOT_AUTHENTICATED' | 'SERVER_ERROR'; data?: never };
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const performQuery = async <T>(query: any): Promise<T | null> => {
+const performQuery = async <T>(query: any): Promise<QueryResult<T>> => {
   const { data, error } = await query;
   if (error) {
     console.error('Failed to execute query', error);
-    return null;
+    return { success: false, error: error.code === 'PGRST116' ? 'NOT_FOUND' : 'SERVER_ERROR' };
   }
-  return data;
+  return { success: true, data };
 };
 
-export const executeQuery = async <T>(query: any): Promise<T | null> => {
+export const executeQuery = async <T>(query: any): Promise<QueryResult<T>> => {
   try {
     return await performQuery(query);
   } catch (err: unknown) {
     console.error(err);
-    return null;
+    return { success: false, error: 'SERVER_ERROR' };
   }
 };

--- a/utils/supabase/__tests__/auth.spec.ts
+++ b/utils/supabase/__tests__/auth.spec.ts
@@ -32,11 +32,11 @@ describe('withAuth', () => {
   });
 
   it('calls fn with the supabase client when a user is logged in', async () => {
-    mockFn.mockResolvedValue('result');
+    mockFn.mockResolvedValue({ success: true, data: 'result' });
     const result = await withAuth(mockFn);
 
     expect(mockFn).toHaveBeenCalledOnce();
-    expect(result).toBe('result');
+    expect(result).toEqual({ success: true, data: 'result' });
   });
 
   it('passes the supabase client to fn', async () => {
@@ -47,7 +47,7 @@ describe('withAuth', () => {
     expect(mockFn).toHaveBeenCalledWith(supabase);
   });
 
-  it('returns null when no user is logged in', async () => {
+  it('returns an error when no user is logged in', async () => {
     mockCreateClient.mockReturnValueOnce({
       auth: {
         getUser: vi.fn().mockResolvedValue({ data: { user: null } }),
@@ -58,6 +58,6 @@ describe('withAuth', () => {
     const result = await withAuth(mockFn);
 
     expect(mockFn).not.toHaveBeenCalled();
-    expect(result).toBeNull();
+    expect(result).toEqual({ success: false, error: 'NOT_AUTHENTICATED' });
   });
 });

--- a/utils/supabase/auth.ts
+++ b/utils/supabase/auth.ts
@@ -1,5 +1,6 @@
 import { SupabaseClient } from '@supabase/supabase-js';
 import { createClient } from './server';
+import { QueryResult } from '../data';
 
 export const isNotLoggedIn = async (): Promise<boolean> => {
   const supabase = createClient();
@@ -11,12 +12,12 @@ export const isNotLoggedIn = async (): Promise<boolean> => {
   return !user;
 };
 
-export const withAuth = async <TResult>(
-  fn: (supabase: SupabaseClient) => Promise<TResult>,
-): Promise<TResult | null> => {
+export const withAuth = async <T>(
+  fn: (supabase: SupabaseClient) => Promise<QueryResult<T>>,
+): Promise<QueryResult<T>> => {
   const supabase = createClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();
-  return user ? await fn(supabase) : null;
+  return user ? await fn(supabase) : { success: false, error: 'NOT_AUTHENTICATED' };
 };


### PR DESCRIPTION
Implement a consistent `QueryResult` structure for all data access operations, providing explicit success or failure status. This change significantly enhances error handling and transaction feedback across the application.

*   **Standardize Data Access Returns**: Update `executeQuery` and `withAuth` to return a `QueryResult` object, which includes a `success` boolean and either `data` or a specific `error` type (`NOT_FOUND`, `NOT_AUTHENTICATED`, `SERVER_ERROR`).
*   **Improve Delete Operations**: Modify all `delete` data functions to return `boolean` reflecting the operation's success, instead of `void`. This allows client-side actions to respond appropriately.
*   **Enhance Action Error Handling**: Update server actions, particularly `deleteConfirmed` functions, to check the result of data operations. Redirect users to specific success pages on completion or to a general `/error` page if the transaction fails.
*   **Refine Test Coverage**: Adjust unit tests and mocks to align with the new `QueryResult` return types and cover new failure scenarios for data transactions and subsequent redirects.

This refactoring ensures clearer transaction outcomes and improves the user experience by providing precise feedback on data mutations.

Relates to #28