### PR TITLE
Create the useForm hook

### DIFF
--- a/app/adventure/notes/ui/note-editor.tsx
+++ b/app/adventure/notes/ui/note-editor.tsx
@@ -1,7 +1,7 @@
 import BusyIndicator from '@/app/ui/busy-indicator';
 import Description from '@/app/ui/description';
 import Input from '@/app/ui/input';
-import { useFormControl } from '@/hooks/use-form-control';
+import { useForm } from '@/hooks/use-form';
 import { Note } from '@/models';
 import { isRequired } from '@/utils/input-validations';
 import { useState } from 'react';
@@ -13,27 +13,22 @@ export interface NoteEditorProps {
 }
 
 const NoteEditor = ({ note, onCancel, onConfirm }: NoteEditorProps) => {
-  const {
-    value: name,
-    error: nameError,
-    setValue: setName,
-    validate: validateName,
-  } = useFormControl(note?.name || '', (value: string) => isRequired(value, 'Topic'));
-  const { value: description, setValue: setDescription } = useFormControl(note?.description || '');
+  const { fields, isDirty } = useForm({
+    name: { initialValue: note?.name || '', validate: (v: string) => isRequired(v, 'Topic') },
+    description: { initialValue: note?.description || '' },
+  });
   const [busy, setBusy] = useState(false);
+
+  const disableConfirmButton = !isDirty || !fields.name.value.trim();
 
   const buildNote = (): Note => ({
     ...note,
-    name,
-    description,
+    name: fields.name.value,
+    description: fields.description.value,
     eventRid: note?.eventRid || null,
     equipmentRid: note?.equipmentRid || null,
     placeRid: note?.placeRid || null,
   });
-
-  const requiredFieldsHaveValues = !!name.trim();
-  const isDirty = name.trim() !== (note?.name || '') || description.trim() !== (note?.description || '');
-  const disableConfirmButton = !(requiredFieldsHaveValues && isDirty);
 
   return (
     <div className="p-2 md:p-4">
@@ -43,19 +38,19 @@ const NoteEditor = ({ note, onCancel, onConfirm }: NoteEditorProps) => {
             id="notes-topic"
             label="Topic"
             className="col-span-4"
-            value={name}
+            value={fields.name.value}
             disabled={busy}
-            error={nameError}
-            onBlur={validateName}
-            onChange={(evt) => setName(evt.target.value)}
+            error={fields.name.error}
+            onBlur={fields.name.validate}
+            onChange={(evt) => fields.name.setValue(evt.target.value)}
           />
           <Description
             id="notes-description"
             label="Description"
             className="col-span-4"
-            value={description}
+            value={fields.description.value}
             disabled={busy}
-            onChange={(evt) => setDescription(evt.target.value)}
+            onChange={(evt) => fields.description.setValue(evt.target.value)}
           />
         </div>
       </section>

--- a/hooks/__tests__/use-form.spec.ts
+++ b/hooks/__tests__/use-form.spec.ts
@@ -136,6 +136,7 @@ describe('useForm', () => {
         result.current.fields.name.setValue('');
         result.current.fields.name.validate();
       });
+      expect(result.current.fields.name.value).toBe('');
       expect(result.current.fields.name.error).toBe('Required');
     });
   });

--- a/hooks/__tests__/use-form.spec.ts
+++ b/hooks/__tests__/use-form.spec.ts
@@ -1,0 +1,258 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useForm } from '../use-form';
+
+describe('useForm', () => {
+  describe('initial state', () => {
+    it('initializes field values from the schema', () => {
+      const { result } = renderHook(() =>
+        useForm({
+          name: { initialValue: 'Alice' },
+          age: { initialValue: 30 },
+        }),
+      );
+      expect(result.current.fields.name.value).toBe('Alice');
+      expect(result.current.fields.age.value).toBe(30);
+    });
+
+    it('has no errors on any field', () => {
+      const { result } = renderHook(() =>
+        useForm({
+          name: { initialValue: '', validate: (v) => (!v ? 'Required' : undefined) },
+        }),
+      );
+      expect(result.current.fields.name.error).toBeUndefined();
+    });
+
+    it('is not dirty', () => {
+      const { result } = renderHook(() =>
+        useForm({
+          name: { initialValue: 'Alice' },
+        }),
+      );
+      expect(result.current.isDirty).toBe(false);
+    });
+
+    it('is valid (no errors shown yet)', () => {
+      const { result } = renderHook(() =>
+        useForm({
+          name: { initialValue: '', validate: (v) => (!v ? 'Required' : undefined) },
+        }),
+      );
+      expect(result.current.isValid).toBe(true);
+    });
+  });
+
+  describe('field.setValue', () => {
+    it('updates the field value', () => {
+      const { result } = renderHook(() => useForm({ name: { initialValue: '' } }));
+      act(() => result.current.fields.name.setValue('Bob'));
+      expect(result.current.fields.name.value).toBe('Bob');
+    });
+
+    it('runs validation and sets an error for an invalid value', () => {
+      const { result } = renderHook(() =>
+        useForm({
+          name: { initialValue: 'valid', validate: (v) => (!v ? 'Required' : undefined) },
+        }),
+      );
+      act(() => result.current.fields.name.setValue(''));
+      expect(result.current.fields.name.error).toBe('Required');
+    });
+
+    it('clears an error when the value becomes valid', () => {
+      const { result } = renderHook(() =>
+        useForm({
+          name: { initialValue: '', validate: (v) => (!v ? 'Required' : undefined) },
+        }),
+      );
+      act(() => result.current.fields.name.validate());
+      expect(result.current.fields.name.error).toBe('Required');
+      act(() => result.current.fields.name.setValue('Alice'));
+      expect(result.current.fields.name.error).toBeUndefined();
+    });
+
+    it('does not affect sibling fields', () => {
+      const { result } = renderHook(() =>
+        useForm({
+          first: { initialValue: 'Alice' },
+          last: { initialValue: 'Smith' },
+        }),
+      );
+      act(() => result.current.fields.first.setValue('Bob'));
+      expect(result.current.fields.last.value).toBe('Smith');
+    });
+  });
+
+  describe('field.validate', () => {
+    it('sets an error when the value fails validation', () => {
+      const { result } = renderHook(() =>
+        useForm({
+          name: { initialValue: '', validate: (v) => (!v ? 'Required' : undefined) },
+        }),
+      );
+      act(() => result.current.fields.name.validate());
+      expect(result.current.fields.name.error).toBe('Required');
+    });
+
+    it('sets no error when the value passes validation', () => {
+      const { result } = renderHook(() =>
+        useForm({
+          name: { initialValue: 'Alice', validate: (v) => (!v ? 'Required' : undefined) },
+        }),
+      );
+      act(() => result.current.fields.name.validate());
+      expect(result.current.fields.name.error).toBeUndefined();
+    });
+
+    it('does not affect sibling fields', () => {
+      const { result } = renderHook(() =>
+        useForm({
+          first: { initialValue: '', validate: (v) => (!v ? 'Required' : undefined) },
+          last: { initialValue: '' },
+        }),
+      );
+      act(() => result.current.fields.first.validate());
+      expect(result.current.fields.last.error).toBeUndefined();
+    });
+  });
+
+  describe('isDirty', () => {
+    it('becomes true when a string field value changes', () => {
+      const { result } = renderHook(() => useForm({ name: { initialValue: 'Alice' } }));
+      act(() => result.current.fields.name.setValue('Bob'));
+      expect(result.current.isDirty).toBe(true);
+    });
+
+    it('remains false when a string field is set to the same value', () => {
+      const { result } = renderHook(() => useForm({ name: { initialValue: 'Alice' } }));
+      act(() => result.current.fields.name.setValue('Alice'));
+      expect(result.current.isDirty).toBe(false);
+    });
+
+    it('remains false when only whitespace is added to a string field (default trim comparison)', () => {
+      const { result } = renderHook(() => useForm({ name: { initialValue: 'Alice' } }));
+      act(() => result.current.fields.name.setValue('Alice   '));
+      expect(result.current.isDirty).toBe(false);
+    });
+
+    it('becomes true when a non-string field changes', () => {
+      const { result } = renderHook(() => useForm({ count: { initialValue: 1 } }));
+      act(() => result.current.fields.count.setValue(2));
+      expect(result.current.isDirty).toBe(true);
+    });
+
+    it('uses a custom equals function when provided', () => {
+      const { result } = renderHook(() =>
+        useForm({
+          name: {
+            initialValue: 'Alice',
+            equals: (a, b) => a === b,
+          },
+        }),
+      );
+      act(() => result.current.fields.name.setValue('Alice   '));
+      expect(result.current.isDirty).toBe(true);
+    });
+
+    it('is true when at least one field has changed', () => {
+      const { result } = renderHook(() =>
+        useForm({
+          first: { initialValue: 'Alice' },
+          last: { initialValue: 'Smith' },
+        }),
+      );
+      act(() => result.current.fields.last.setValue('Jones'));
+      expect(result.current.isDirty).toBe(true);
+    });
+  });
+
+  describe('isValid', () => {
+    it('is false when any field has an error', () => {
+      const { result } = renderHook(() =>
+        useForm({
+          name: { initialValue: '', validate: (v) => (!v ? 'Required' : undefined) },
+        }),
+      );
+      act(() => result.current.fields.name.validate());
+      expect(result.current.isValid).toBe(false);
+    });
+
+    it('returns to true after the error is resolved', () => {
+      const { result } = renderHook(() =>
+        useForm({
+          name: { initialValue: '', validate: (v) => (!v ? 'Required' : undefined) },
+        }),
+      );
+      act(() => result.current.fields.name.validate());
+      expect(result.current.isValid).toBe(false);
+      act(() => result.current.fields.name.setValue('Alice'));
+      expect(result.current.isValid).toBe(true);
+    });
+  });
+
+  describe('validateAll', () => {
+    it('triggers validation for every field', () => {
+      const { result } = renderHook(() =>
+        useForm({
+          first: { initialValue: '', validate: (v) => (!v ? 'First required' : undefined) },
+          last: { initialValue: '', validate: (v) => (!v ? 'Last required' : undefined) },
+        }),
+      );
+      act(() => result.current.validateAll());
+      expect(result.current.fields.first.error).toBe('First required');
+      expect(result.current.fields.last.error).toBe('Last required');
+    });
+
+    it('clears errors for fields that now pass validation', () => {
+      const { result } = renderHook(() =>
+        useForm({
+          name: { initialValue: '', validate: (v) => (!v ? 'Required' : undefined) },
+        }),
+      );
+      act(() => result.current.fields.name.validate());
+      expect(result.current.fields.name.error).toBe('Required');
+      act(() => result.current.fields.name.setValue('Alice'));
+      act(() => result.current.validateAll());
+      expect(result.current.fields.name.error).toBeUndefined();
+    });
+  });
+
+  describe('reset', () => {
+    it('restores all field values to their initial values', () => {
+      const { result } = renderHook(() =>
+        useForm({
+          name: { initialValue: 'Alice' },
+          age: { initialValue: 30 },
+        }),
+      );
+      act(() => {
+        result.current.fields.name.setValue('Bob');
+        result.current.fields.age.setValue(99);
+      });
+      act(() => result.current.reset());
+      expect(result.current.fields.name.value).toBe('Alice');
+      expect(result.current.fields.age.value).toBe(30);
+    });
+
+    it('clears all errors', () => {
+      const { result } = renderHook(() =>
+        useForm({
+          name: { initialValue: '', validate: (v) => (!v ? 'Required' : undefined) },
+        }),
+      );
+      act(() => result.current.fields.name.validate());
+      expect(result.current.fields.name.error).toBe('Required');
+      act(() => result.current.reset());
+      expect(result.current.fields.name.error).toBeUndefined();
+    });
+
+    it('sets isDirty back to false', () => {
+      const { result } = renderHook(() => useForm({ name: { initialValue: 'Alice' } }));
+      act(() => result.current.fields.name.setValue('Bob'));
+      expect(result.current.isDirty).toBe(true);
+      act(() => result.current.reset());
+      expect(result.current.isDirty).toBe(false);
+    });
+  });
+});

--- a/hooks/__tests__/use-form.spec.ts
+++ b/hooks/__tests__/use-form.spec.ts
@@ -41,6 +41,16 @@ describe('useForm', () => {
       );
       expect(result.current.isValid).toBe(true);
     });
+
+    it("treats an empty string validation result as no error", () => {
+      const { result } = renderHook(() =>
+        useForm({
+          name: { initialValue: 'Alice', validate: (v) => (v ? '' : 'Required') },
+        }),
+      );
+      expect(result.current.fields.name.error).toBeFalsy();
+      expect(result.current.isValid).toBe(true);
+    });
   });
 
   describe('field.setValue', () => {

--- a/hooks/__tests__/use-form.spec.ts
+++ b/hooks/__tests__/use-form.spec.ts
@@ -42,7 +42,7 @@ describe('useForm', () => {
       expect(result.current.isValid).toBe(true);
     });
 
-    it("treats an empty string validation result as no error", () => {
+    it('treats an empty string validation result as no error', () => {
       const { result } = renderHook(() =>
         useForm({
           name: { initialValue: 'Alice', validate: (v) => (v ? '' : 'Required') },
@@ -162,6 +162,28 @@ describe('useForm', () => {
         }),
       );
       act(() => result.current.fields.name.setValue('Alice   '));
+      expect(result.current.isDirty).toBe(true);
+    });
+
+    it('does not flip isDirty when the schema initialValue changes between renders', () => {
+      const { result, rerender } = renderHook(
+        ({ initialName }: { initialName: string }) => useForm({ name: { initialValue: initialName } }),
+        { initialProps: { initialName: 'Alice' } },
+      );
+      expect(result.current.isDirty).toBe(false);
+      rerender({ initialName: 'Bob' });
+      expect(result.current.isDirty).toBe(false);
+    });
+
+    it('uses the updated schema initialValue as the baseline after reset', () => {
+      const { result, rerender } = renderHook(
+        ({ initialName }: { initialName: string }) => useForm({ name: { initialValue: initialName } }),
+        { initialProps: { initialName: 'Alice' } },
+      );
+      rerender({ initialName: 'Bob' });
+      act(() => result.current.reset());
+      expect(result.current.isDirty).toBe(false);
+      act(() => result.current.fields.name.setValue('Alice'));
       expect(result.current.isDirty).toBe(true);
     });
 

--- a/hooks/__tests__/use-form.spec.ts
+++ b/hooks/__tests__/use-form.spec.ts
@@ -125,6 +125,19 @@ describe('useForm', () => {
       act(() => result.current.fields.first.validate());
       expect(result.current.fields.last.error).toBeUndefined();
     });
+
+    it('uses the latest value when called immediately after setValue in the same tick', () => {
+      const { result } = renderHook(() =>
+        useForm({
+          name: { initialValue: 'Alice', validate: (v) => (!v ? 'Required' : undefined) },
+        }),
+      );
+      act(() => {
+        result.current.fields.name.setValue('');
+        result.current.fields.name.validate();
+      });
+      expect(result.current.fields.name.error).toBe('Required');
+    });
   });
 
   describe('isDirty', () => {

--- a/hooks/use-form.ts
+++ b/hooks/use-form.ts
@@ -30,6 +30,17 @@ const defaultEquals = <T>(current: T, initial: T): boolean => {
 };
 
 export const useForm = <S extends SchemaBase>(schema: S) => {
+  // Stable snapshot of initial values captured once at mount; only updated by
+  // an explicit reset() call so isDirty never flips due to parent re-renders
+  // supplying different initialValue props.
+  const [initialValues, setInitialValues] = useState<FormValues<S>>(() => {
+    const init = {} as FormValues<S>;
+    for (const key in schema) {
+      (init as Record<string, unknown>)[key] = schema[key].initialValue;
+    }
+    return init;
+  });
+
   const [values, setValues] = useState<FormValues<S>>(() => {
     const init = {} as FormValues<S>;
     for (const key in schema) {
@@ -64,7 +75,7 @@ export const useForm = <S extends SchemaBase>(schema: S) => {
     const eq =
       (schema[k].equals as ((c: InferValue<S[typeof k]>, i: InferValue<S[typeof k]>) => boolean) | undefined) ??
       defaultEquals;
-    return !eq(values[k], schema[k].initialValue as InferValue<S[typeof k]>);
+    return !eq(values[k], initialValues[k]);
   });
 
   const isValid = Object.keys(schema).every((key) => !errors[key as keyof S]);
@@ -81,11 +92,12 @@ export const useForm = <S extends SchemaBase>(schema: S) => {
   };
 
   const reset = () => {
-    const init = {} as FormValues<S>;
+    const newInit = {} as FormValues<S>;
     for (const key in schema) {
-      (init as Record<string, unknown>)[key] = schema[key].initialValue;
+      (newInit as Record<string, unknown>)[key] = schema[key].initialValue;
     }
-    setValues(init);
+    setInitialValues(newInit);
+    setValues(newInit);
     setErrors({} as FormErrors<S>);
   };
 

--- a/hooks/use-form.ts
+++ b/hooks/use-form.ts
@@ -29,25 +29,21 @@ const defaultEquals = <T>(current: T, initial: T): boolean => {
   return current === initial;
 };
 
+const buildValues = <S extends SchemaBase>(schema: S): FormValues<S> => {
+  const init = {} as FormValues<S>;
+  for (const key in schema) {
+    (init as Record<string, unknown>)[key] = schema[key].initialValue;
+  }
+  return init;
+};
+
 export const useForm = <S extends SchemaBase>(schema: S) => {
   // Stable snapshot of initial values captured once at mount; only updated by
   // an explicit reset() call so isDirty never flips due to parent re-renders
   // supplying different initialValue props.
-  const [initialValues, setInitialValues] = useState<FormValues<S>>(() => {
-    const init = {} as FormValues<S>;
-    for (const key in schema) {
-      (init as Record<string, unknown>)[key] = schema[key].initialValue;
-    }
-    return init;
-  });
+  const [initialValues, setInitialValues] = useState<FormValues<S>>(() => buildValues(schema));
 
-  const [values, setValues] = useState<FormValues<S>>(() => {
-    const init = {} as FormValues<S>;
-    for (const key in schema) {
-      (init as Record<string, unknown>)[key] = schema[key].initialValue;
-    }
-    return init;
-  });
+  const [values, setValues] = useState<FormValues<S>>(() => buildValues(schema));
 
   const [errors, setErrors] = useState<FormErrors<S>>({} as FormErrors<S>);
 
@@ -92,10 +88,7 @@ export const useForm = <S extends SchemaBase>(schema: S) => {
   };
 
   const reset = () => {
-    const newInit = {} as FormValues<S>;
-    for (const key in schema) {
-      (newInit as Record<string, unknown>)[key] = schema[key].initialValue;
-    }
+    const newInit = buildValues(schema);
     setInitialValues(newInit);
     setValues(newInit);
     setErrors({} as FormErrors<S>);

--- a/hooks/use-form.ts
+++ b/hooks/use-form.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
 export type FieldConfig<T> = {
   initialValue: T;
@@ -45,6 +45,11 @@ export const useForm = <S extends SchemaBase>(schema: S) => {
 
   const [values, setValues] = useState<FormValues<S>>(() => buildValues(schema));
 
+  // Tracks the latest field values synchronously so validate() always runs
+  // against the current value even when called immediately after setValue()
+  // in the same React tick (before the state update is committed).
+  const valuesRef = useRef<FormValues<S>>(values);
+
   const [errors, setErrors] = useState<FormErrors<S>>({} as FormErrors<S>);
 
   const fields = Object.keys(schema).reduce((acc, key) => {
@@ -54,12 +59,13 @@ export const useForm = <S extends SchemaBase>(schema: S) => {
       value: values[k],
       error: errors[k],
       setValue: (val: InferValue<S[typeof k]>) => {
+        valuesRef.current = { ...valuesRef.current, [k]: val };
         setValues((prev) => ({ ...prev, [k]: val }));
         const err = schema[k].validate ? schema[k].validate!(val) : undefined;
         setErrors((prev) => ({ ...prev, [k]: err }));
       },
       validate: () => {
-        const err = schema[k].validate ? schema[k].validate!(values[k]) : undefined;
+        const err = schema[k].validate ? schema[k].validate!(valuesRef.current[k]) : undefined;
         setErrors((prev) => ({ ...prev, [k]: err }));
       },
     };
@@ -81,7 +87,7 @@ export const useForm = <S extends SchemaBase>(schema: S) => {
     for (const key in schema) {
       const k = key as keyof S;
       (newErrors as Record<string, string | undefined>)[key] = schema[k].validate
-        ? schema[k].validate!(values[k])
+        ? schema[k].validate!(valuesRef.current[k])
         : undefined;
     }
     setErrors(newErrors);
@@ -89,6 +95,7 @@ export const useForm = <S extends SchemaBase>(schema: S) => {
 
   const reset = () => {
     const newInit = buildValues(schema);
+    valuesRef.current = newInit;
     setInitialValues(newInit);
     setValues(newInit);
     setErrors({} as FormErrors<S>);

--- a/hooks/use-form.ts
+++ b/hooks/use-form.ts
@@ -48,7 +48,7 @@ export const useForm = <S extends SchemaBase>(schema: S) => {
   // Tracks the latest field values synchronously so validate() always runs
   // against the current value even when called immediately after setValue()
   // in the same React tick (before the state update is committed).
-  const valuesRef = useRef<FormValues<S>>(values);
+  const valuesRef = useRef<FormValues<S>>(buildValues(schema));
 
   const [errors, setErrors] = useState<FormErrors<S>>({} as FormErrors<S>);
 

--- a/hooks/use-form.ts
+++ b/hooks/use-form.ts
@@ -7,7 +7,8 @@ export type FieldConfig<T> = {
   equals?: (current: T, initial: T) => boolean;
 };
 
-type SchemaBase = Record<string, FieldConfig<unknown>>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SchemaBase = Record<string, FieldConfig<any>>;
 type InferValue<C> = C extends FieldConfig<infer T> ? T : never;
 type FormValues<S extends SchemaBase> = { [K in keyof S]: InferValue<S[K]> };
 type FormErrors<S extends SchemaBase> = { [K in keyof S]?: string };
@@ -41,7 +42,8 @@ export const useForm = <S extends SchemaBase>(schema: S) => {
 
   const fields = Object.keys(schema).reduce((acc, key) => {
     const k = key as keyof S;
-    (acc as Record<string, FieldState<unknown>>)[key] = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (acc as Record<string, FieldState<any>>)[key] = {
       value: values[k],
       error: errors[k],
       setValue: (val: InferValue<S[typeof k]>) => {

--- a/hooks/use-form.ts
+++ b/hooks/use-form.ts
@@ -1,0 +1,91 @@
+import { useState } from 'react';
+
+export type FieldConfig<T> = {
+  initialValue: T;
+  validate?: (val: T) => string | undefined;
+  /** Override equality for isDirty. Defaults to trimmed string comparison for strings, === otherwise. */
+  equals?: (current: T, initial: T) => boolean;
+};
+
+type SchemaBase = Record<string, FieldConfig<unknown>>;
+type InferValue<C> = C extends FieldConfig<infer T> ? T : never;
+type FormValues<S extends SchemaBase> = { [K in keyof S]: InferValue<S[K]> };
+type FormErrors<S extends SchemaBase> = { [K in keyof S]?: string };
+
+export type FieldState<T> = {
+  value: T;
+  error: string | undefined;
+  setValue: (val: T) => void;
+  validate: () => void;
+};
+
+export type FormFields<S extends SchemaBase> = { [K in keyof S]: FieldState<InferValue<S[K]>> };
+
+const defaultEquals = <T>(current: T, initial: T): boolean => {
+  if (typeof current === 'string' && typeof initial === 'string') {
+    return current.trim() === initial.trim();
+  }
+  return current === initial;
+};
+
+export const useForm = <S extends SchemaBase>(schema: S) => {
+  const [values, setValues] = useState<FormValues<S>>(() => {
+    const init = {} as FormValues<S>;
+    for (const key in schema) {
+      (init as Record<string, unknown>)[key] = schema[key].initialValue;
+    }
+    return init;
+  });
+
+  const [errors, setErrors] = useState<FormErrors<S>>({} as FormErrors<S>);
+
+  const fields = Object.keys(schema).reduce((acc, key) => {
+    const k = key as keyof S;
+    (acc as Record<string, FieldState<unknown>>)[key] = {
+      value: values[k],
+      error: errors[k],
+      setValue: (val: InferValue<S[typeof k]>) => {
+        setValues((prev) => ({ ...prev, [k]: val }));
+        const err = schema[k].validate ? schema[k].validate!(val) : undefined;
+        setErrors((prev) => ({ ...prev, [k]: err }));
+      },
+      validate: () => {
+        const err = schema[k].validate ? schema[k].validate!(values[k]) : undefined;
+        setErrors((prev) => ({ ...prev, [k]: err }));
+      },
+    };
+    return acc;
+  }, {} as FormFields<S>);
+
+  const isDirty = Object.keys(schema).some((key) => {
+    const k = key as keyof S;
+    const eq =
+      (schema[k].equals as ((c: InferValue<S[typeof k]>, i: InferValue<S[typeof k]>) => boolean) | undefined) ??
+      defaultEquals;
+    return !eq(values[k], schema[k].initialValue as InferValue<S[typeof k]>);
+  });
+
+  const isValid = Object.keys(schema).every((key) => !errors[key as keyof S]);
+
+  const validateAll = () => {
+    const newErrors = {} as FormErrors<S>;
+    for (const key in schema) {
+      const k = key as keyof S;
+      (newErrors as Record<string, string | undefined>)[key] = schema[k].validate
+        ? schema[k].validate!(values[k])
+        : undefined;
+    }
+    setErrors(newErrors);
+  };
+
+  const reset = () => {
+    const init = {} as FormValues<S>;
+    for (const key in schema) {
+      (init as Record<string, unknown>)[key] = schema[key].initialValue;
+    }
+    setValues(init);
+    setErrors({} as FormErrors<S>);
+  };
+
+  return { fields, isDirty, isValid, validateAll, reset };
+};


### PR DESCRIPTION
After evaluating the other options, I have decided to go with this one for a couple of primary reasons:

- It is conceptually simple
- It reduces repeated code without fundamentally changing the editors
- It is very similar to the React Hook Form library, but is not yet another dependency
- Since we control the code, we can make it do what we want if need be