### PR TITLE
Refine dashboard event filtering and display

### DIFF
--- a/.changeset/shy-needles-cut.md
+++ b/.changeset/shy-needles-cut.md
@@ -1,0 +1,5 @@
+---
+'recreation-planner': minor
+---
+
+Show key upcoming events in the dashboard. Limit prior events on the dashboard to one week.

--- a/app/adventure/__tests__/page.spec.tsx
+++ b/app/adventure/__tests__/page.spec.tsx
@@ -1,8 +1,11 @@
+import { EVENT_TYPES } from '@/app/adventure/events/__mocks__/data';
 import { fetchPriorEvents, fetchUpcomingEvents } from '@/app/adventure/events/data';
+import { PLACES } from '@/app/adventure/places/__mocks__/data';
 import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import HomePage from '../page';
 import { fetchDueTodoCollections } from '../todos/data';
+import { Event } from '@/models';
 
 vi.mock('@/app/adventure/events/data');
 vi.mock('@/app/adventure/todos/data');
@@ -40,5 +43,83 @@ describe('Adventures Home Page', () => {
     const jsx = await HomePage();
     render(jsx);
     expect(screen.getByRole('heading', { level: 1, name: 'Dashboard' })).toBeDefined();
+  });
+});
+
+describe('current events categorization', () => {
+  const makeEvent = (id: number, name: string, beginDate: string): Event => ({
+    id,
+    name,
+    description: null,
+    beginDate,
+    place: PLACES[0],
+    type: EVENT_TYPES[0],
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2024, 8, 3));
+    vi.mocked(fetchPriorEvents).mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it('displays events that begin within the next two weeks', async () => {
+    vi.mocked(fetchUpcomingEvents).mockResolvedValue([
+      makeEvent(1, 'Near Event 1', '2024-09-05'),
+      makeEvent(2, 'Near Event 2', '2024-09-10'),
+      makeEvent(3, 'Near Event 3', '2024-09-15'),
+      makeEvent(4, 'Far Event', '2024-10-01'),
+    ]);
+    const jsx = await HomePage();
+    render(jsx);
+    expect(screen.queryByText('Near Event 1')).not.toBeNull();
+    expect(screen.queryByText('Near Event 2')).not.toBeNull();
+    expect(screen.queryByText('Near Event 3')).not.toBeNull();
+    expect(screen.queryByText('Far Event')).toBeNull();
+  });
+
+  it('displays the first three events when fewer than three qualify within two weeks', async () => {
+    vi.mocked(fetchUpcomingEvents).mockResolvedValue([
+      makeEvent(1, 'Near Event 1', '2024-09-05'),
+      makeEvent(2, 'Near Event 2', '2024-09-10'),
+      makeEvent(3, 'Far Event 1', '2024-10-01'),
+      makeEvent(4, 'Far Event 2', '2024-10-15'),
+    ]);
+    const jsx = await HomePage();
+    render(jsx);
+    expect(screen.queryByText('Near Event 1')).not.toBeNull();
+    expect(screen.queryByText('Near Event 2')).not.toBeNull();
+    expect(screen.queryByText('Far Event 1')).not.toBeNull();
+    expect(screen.queryByText('Far Event 2')).toBeNull();
+  });
+
+  it('displays both events when there are only two upcoming events', async () => {
+    vi.mocked(fetchUpcomingEvents).mockResolvedValue([
+      makeEvent(1, 'Event One', '2024-09-05'),
+      makeEvent(2, 'Event Two', '2024-09-10'),
+    ]);
+    const jsx = await HomePage();
+    render(jsx);
+    expect(screen.queryByText('Event One')).not.toBeNull();
+    expect(screen.queryByText('Event Two')).not.toBeNull();
+  });
+
+  it('displays the event when there is only one upcoming event', async () => {
+    vi.mocked(fetchUpcomingEvents).mockResolvedValue([makeEvent(1, 'Solo Event', '2024-09-05')]);
+    const jsx = await HomePage();
+    render(jsx);
+    expect(screen.queryByText('Solo Event')).not.toBeNull();
+  });
+
+  it('displays a message when there are no upcoming events', async () => {
+    vi.mocked(fetchUpcomingEvents).mockResolvedValue([]);
+    const jsx = await HomePage();
+    render(jsx);
+    expect(screen.getByText('You have no upcoming events.')).toBeDefined();
   });
 });

--- a/app/adventure/__tests__/page.spec.tsx
+++ b/app/adventure/__tests__/page.spec.tsx
@@ -1,7 +1,6 @@
-import { fetchUpcomingEvents } from '@/app/adventure/events/data';
+import { fetchPriorEvents, fetchUpcomingEvents } from '@/app/adventure/events/data';
 import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { fetchLatestEvents } from '../events/__mocks__/data';
 import HomePage from '../page';
 import { fetchDueTodoCollections } from '../todos/data';
 
@@ -22,18 +21,19 @@ describe('Adventures Home Page', () => {
   it('fetches the current events', async () => {
     vi.setSystemTime(new Date(2024, 8, 3));
     await HomePage();
-    expect(fetchUpcomingEvents).toHaveBeenCalledExactlyOnceWith('2024-09-01', '2024-09-28');
+    expect(fetchUpcomingEvents).toHaveBeenCalledExactlyOnceWith('2024-09-03');
   });
 
-  it('fetchs the latest three created events', async () => {
-    await HomePage();
-    expect(fetchLatestEvents).toHaveBeenCalledExactlyOnceWith(3);
-  });
-
-  it('fetches due todo collections', async () => {
+  it('fetches the events for last week', async () => {
     vi.setSystemTime(new Date(2024, 8, 3));
     await HomePage();
-    expect(fetchDueTodoCollections).toHaveBeenCalledExactlyOnceWith('2024-09-07');
+    expect(fetchPriorEvents).toHaveBeenCalledExactlyOnceWith('2024-09-03', '2024-08-27');
+  });
+
+  it('fetches due todo collections due within a week', async () => {
+    vi.setSystemTime(new Date(2024, 8, 3));
+    await HomePage();
+    expect(fetchDueTodoCollections).toHaveBeenCalledExactlyOnceWith('2024-09-10');
   });
 
   it('renders the dashboard component', async () => {

--- a/app/adventure/equipment/__tests__/data.spec.ts
+++ b/app/adventure/equipment/__tests__/data.spec.ts
@@ -1,4 +1,4 @@
-import { buildChainableMock, setLoggedIn, setLoggedOut } from '@/test-utils/data-helpers';
+import { buildSupabaseChainableMock, setLoggedIn, setLoggedOut } from '@/test-utils/data-helpers';
 import { executeQuery } from '@/utils/data';
 import { createClient } from '@/utils/supabase/server';
 import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
@@ -105,7 +105,7 @@ describe('equipment data', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    const chain = buildChainableMock();
+    const chain = buildSupabaseChainableMock();
     mockFrom = vi.fn().mockReturnValue(chain);
     const client = createClient();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/app/adventure/events/[id]/itinerary/__tests__/data.spec.ts
+++ b/app/adventure/events/[id]/itinerary/__tests__/data.spec.ts
@@ -8,7 +8,7 @@ import {
   fetchItineraryItem,
   updateItineraryItem,
 } from '../data';
-import { buildChainableMock, setLoggedIn, setLoggedOut } from '@/test-utils/data-helpers';
+import { buildSupabaseChainableMock, setLoggedIn, setLoggedOut } from '@/test-utils/data-helpers';
 
 vi.mock('@/utils/supabase/server');
 vi.mock('@/utils/data', () => ({ executeQuery: vi.fn() }));
@@ -40,7 +40,7 @@ describe('itinerary data', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    const chain = buildChainableMock();
+    const chain = buildSupabaseChainableMock();
     mockFrom = vi.fn().mockReturnValue(chain);
     const client = createClient();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/app/adventure/events/__tests__/data.spec.ts
+++ b/app/adventure/events/__tests__/data.spec.ts
@@ -12,7 +12,12 @@ import {
   fetchUpcomingEvents,
   updateEvent,
 } from '../data';
-import { buildChainableMock, setLoggedIn, setLoggedOut } from '@/test-utils/data-helpers';
+import {
+  buildSupabaseChainableMock,
+  setLoggedIn,
+  setLoggedOut,
+  SupabaseChainableMock,
+} from '@/test-utils/data-helpers';
 
 vi.mock('@/utils/supabase/server');
 vi.mock('@/utils/data', () => ({ executeQuery: vi.fn() }));
@@ -88,12 +93,12 @@ const event = {
 // --- Tests ---
 
 describe('events data', () => {
+  const supabaseMocks: SupabaseChainableMock = buildSupabaseChainableMock();
   let mockFrom: Mock;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    const chain = buildChainableMock();
-    mockFrom = vi.fn().mockReturnValue(chain);
+    mockFrom = vi.fn().mockReturnValue(supabaseMocks);
     const client = createClient();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vi.mocked(createClient).mockReturnValue({ ...client, from: mockFrom } as any);
@@ -192,6 +197,13 @@ describe('events data', () => {
         it('queries the events table', async () => {
           await fetchPriorEvents('2024-01-01');
           expect(mockFrom).toHaveBeenCalledExactlyOnceWith('events');
+        });
+
+        it('limits by end date with begin date as fallback', async () => {
+          await fetchPriorEvents('2024-01-01');
+          expect(supabaseMocks.or).toHaveBeenCalledExactlyOnceWith(
+            'end_date.lt."2024-01-01",and(end_date.is.null,begin_date.lt."2024-01-01")',
+          );
         });
 
         it('returns the converted events list', async () => {

--- a/app/adventure/events/__tests__/data.spec.ts
+++ b/app/adventure/events/__tests__/data.spec.ts
@@ -149,6 +149,18 @@ describe('events data', () => {
           await fetchUpcomingEvents('2024-01-01', '2024-12-31');
           expect(mockFrom).toHaveBeenCalledExactlyOnceWith('events');
         });
+
+        it('limits to greater than or equal to date', async () => {
+          await fetchUpcomingEvents('2024-01-01');
+          expect(supabaseMocks.gte).toHaveBeenCalledExactlyOnceWith('effective_end_date', '2024-01-01');
+          expect(supabaseMocks.lte).not.toHaveBeenCalled();
+        });
+
+        it('limits based on the date window when two dates are given', async () => {
+          await fetchUpcomingEvents('2024-01-01', '2024-12-31');
+          expect(supabaseMocks.gte).toHaveBeenCalledExactlyOnceWith('effective_end_date', '2024-01-01');
+          expect(supabaseMocks.lte).toHaveBeenCalledExactlyOnceWith('effective_end_date', '2024-12-31');
+        });
       });
 
       describe('when no data is returned', () => {
@@ -199,11 +211,16 @@ describe('events data', () => {
           expect(mockFrom).toHaveBeenCalledExactlyOnceWith('events');
         });
 
-        it('limits by end date with begin date as fallback', async () => {
+        it('limits by effective end date', async () => {
           await fetchPriorEvents('2024-01-01');
-          expect(supabaseMocks.or).toHaveBeenCalledExactlyOnceWith(
-            'end_date.lt."2024-01-01",and(end_date.is.null,begin_date.lt."2024-01-01")',
-          );
+          expect(supabaseMocks.lt).toHaveBeenCalledExactlyOnceWith('effective_end_date', '2024-01-01');
+          expect(supabaseMocks.gte).not.toHaveBeenCalled();
+        });
+
+        it('limits to a window of time if two dates are given', async () => {
+          await fetchPriorEvents('2024-01-01', '2023-12-15');
+          expect(supabaseMocks.lt).toHaveBeenCalledExactlyOnceWith('effective_end_date', '2024-01-01');
+          expect(supabaseMocks.gte).toHaveBeenCalledExactlyOnceWith('effective_end_date', '2023-12-15');
         });
 
         it('returns the converted events list', async () => {

--- a/app/adventure/events/data.ts
+++ b/app/adventure/events/data.ts
@@ -12,24 +12,19 @@ const childTableColumns = ', itinerary_items(*), notes(*), todo_collections(*, t
 const eventsTable = 'events';
 
 const upcomingEventsQuery = (supabase: SupabaseClient, startDate: string, endDate?: string): any => {
-  let query = supabase
-    .from(eventsTable)
-    .select(selectColumns)
-    .or(`end_date.gte."${startDate}",and(end_date.is.null,begin_date.gte."${startDate}")`);
+  let query = supabase.from(eventsTable).select(selectColumns).gte('effective_end_date', startDate);
   if (endDate) {
-    query = query.or(`end_date.lte."${endDate}",and(end_date.is.null,begin_date.lte."${endDate}")`);
+    query = query.lte('effective_end_date', endDate);
   }
-
   return query.order('begin_date').order('begin_time', { nullsFirst: true });
 };
 
-const priorEventsQuery = (supabase: SupabaseClient, dt: string, endDate?: string): any => {
-  return supabase
-    .from(eventsTable)
-    .select(selectColumns)
-    .or(`end_date.lt."${dt}",and(end_date.is.null,begin_date.lt."${dt}")`)
-    .order('begin_date', { ascending: false })
-    .order('begin_time', { ascending: false, nullsFirst: false });
+const priorEventsQuery = (supabase: SupabaseClient, beforeDate: string, afterDate?: string): any => {
+  let query = supabase.from(eventsTable).select(selectColumns).lt('effective_end_date', beforeDate);
+  if (afterDate) {
+    query = query.gte('effective_end_date', afterDate);
+  }
+  return query.order('begin_date', { ascending: false }).order('begin_time', { ascending: false, nullsFirst: false });
 };
 
 const lastCreatedEventsQuery = (supabase: SupabaseClient, x: number) => {

--- a/app/adventure/events/data.ts
+++ b/app/adventure/events/data.ts
@@ -23,7 +23,7 @@ const upcomingEventsQuery = (supabase: SupabaseClient, startDate: string, endDat
   return query.order('begin_date').order('begin_time', { nullsFirst: true });
 };
 
-const priorEventsQuery = (supabase: SupabaseClient, dt: string): any => {
+const priorEventsQuery = (supabase: SupabaseClient, dt: string, endDate?: string): any => {
   return supabase
     .from(eventsTable)
     .select(selectColumns)
@@ -74,8 +74,10 @@ export const fetchUpcomingEvents = async (startDate: string, endDate?: string): 
   return (res.success ? res.data : []).map((p) => convertToEvent(p) as Event);
 };
 
-export const fetchPriorEvents = async (dt: string): Promise<Event[]> => {
-  const res = await withAuth((supabase: SupabaseClient) => executeQuery<EventDTO[]>(priorEventsQuery(supabase, dt)));
+export const fetchPriorEvents = async (dt: string, endDate?: string): Promise<Event[]> => {
+  const res = await withAuth((supabase: SupabaseClient) =>
+    executeQuery<EventDTO[]>(priorEventsQuery(supabase, dt, endDate)),
+  );
   return (res.success ? res.data : []).map((p) => convertToEvent(p) as Event);
 };
 

--- a/app/adventure/events/data.ts
+++ b/app/adventure/events/data.ts
@@ -69,9 +69,9 @@ export const fetchUpcomingEvents = async (startDate: string, endDate?: string): 
   return (res.success ? res.data : []).map((p) => convertToEvent(p) as Event);
 };
 
-export const fetchPriorEvents = async (dt: string, endDate?: string): Promise<Event[]> => {
+export const fetchPriorEvents = async (beforeDate: string, afterDate?: string): Promise<Event[]> => {
   const res = await withAuth((supabase: SupabaseClient) =>
-    executeQuery<EventDTO[]>(priorEventsQuery(supabase, dt, endDate)),
+    executeQuery<EventDTO[]>(priorEventsQuery(supabase, beforeDate, afterDate)),
   );
   return (res.success ? res.data : []).map((p) => convertToEvent(p) as Event);
 };

--- a/app/adventure/notes/__tests__/data.spec.ts
+++ b/app/adventure/notes/__tests__/data.spec.ts
@@ -1,4 +1,4 @@
-import { buildChainableMock, setLoggedIn, setLoggedOut } from '@/test-utils/data-helpers';
+import { buildSupabaseChainableMock, setLoggedIn, setLoggedOut } from '@/test-utils/data-helpers';
 import { executeQuery } from '@/utils/data';
 import { createClient } from '@/utils/supabase/server';
 import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
@@ -34,7 +34,7 @@ describe('notes data', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    const chain = buildChainableMock();
+    const chain = buildSupabaseChainableMock();
     mockFrom = vi.fn().mockReturnValue(chain);
     const client = createClient();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/app/adventure/page.tsx
+++ b/app/adventure/page.tsx
@@ -1,20 +1,27 @@
-import { addWeeks, endOfWeek, formatISO, startOfWeek } from 'date-fns';
+import { addWeeks, formatISO } from 'date-fns';
 import PageHeader from '../ui/page-header';
 import TitleHeading from '../ui/title-heading';
 import Dashboard from './dashboard';
-import { fetchLatestEvents, fetchUpcomingEvents } from './events/data';
+import { fetchPriorEvents, fetchUpcomingEvents } from './events/data';
 import { fetchDueTodoCollections } from './todos/data';
+import { Event } from '@/models';
 
 const dateToString = (dt: Date) => formatISO(dt, { representation: 'date' });
 
-const getHomePageData = async () => {
-  const now = Date.now();
-  const weekStartDate = startOfWeek(now);
-  const weekEndDate = endOfWeek(now);
+const firstThreeEvents = (events: Event[]) => events.slice(0, Math.min(3, events.length));
+const filterCurrentEvents = (events: Event[], dt: string) => events.filter((e) => e.beginDate <= dt);
 
-  const currentEvents = await fetchUpcomingEvents(dateToString(weekStartDate), dateToString(addWeeks(weekEndDate, 3)));
-  const latestEvents = await fetchLatestEvents(3);
-  const todoCollections = await fetchDueTodoCollections(dateToString(weekEndDate));
+const getHomePageData = async () => {
+  const now = new Date();
+
+  const allEvents = await fetchUpcomingEvents(dateToString(now));
+  const latestEvents = await fetchPriorEvents(dateToString(now), dateToString(addWeeks(now, -1)));
+  const todoCollections = await fetchDueTodoCollections(dateToString(addWeeks(now, 1)));
+
+  let currentEvents = filterCurrentEvents(allEvents, dateToString(addWeeks(now, 2)));
+  if (currentEvents.length < 3) {
+    currentEvents = firstThreeEvents(allEvents);
+  }
 
   return { currentEvents, latestEvents, todoCollections };
 };

--- a/app/adventure/places/__tests__/data.spec.ts
+++ b/app/adventure/places/__tests__/data.spec.ts
@@ -1,4 +1,4 @@
-import { buildChainableMock, setLoggedIn, setLoggedOut } from '@/test-utils/data-helpers';
+import { buildSupabaseChainableMock, setLoggedIn, setLoggedOut } from '@/test-utils/data-helpers';
 import { executeQuery } from '@/utils/data';
 import { createClient } from '@/utils/supabase/server';
 import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
@@ -77,7 +77,7 @@ describe('places data', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    const chain = buildChainableMock();
+    const chain = buildSupabaseChainableMock();
     mockFrom = vi.fn().mockReturnValue(chain);
     const client = createClient();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/app/adventure/todos/__tests__/data.spec.ts
+++ b/app/adventure/todos/__tests__/data.spec.ts
@@ -14,7 +14,7 @@ import {
   updateTodoCollection,
   updateTodoItem,
 } from '../data';
-import { buildChainableMock, setLoggedIn, setLoggedOut } from '@/test-utils/data-helpers';
+import { buildSupabaseChainableMock, setLoggedIn, setLoggedOut } from '@/test-utils/data-helpers';
 
 vi.mock('@/utils/supabase/server');
 vi.mock('@/utils/data', () => ({ executeQuery: vi.fn() }));
@@ -76,7 +76,7 @@ describe('todos data', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    const chain = buildChainableMock();
+    const chain = buildSupabaseChainableMock();
     mockFrom = vi.fn().mockReturnValue(chain);
     const client = createClient();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/scripts/events-effective-end-date.sql
+++ b/scripts/events-effective-end-date.sql
@@ -1,0 +1,4 @@
+create or replace function effective_end_date(event_row events)
+returns date as $$
+  select coalesce(event_row.end_date, event_row.begin_date);
+$$ language sql immutable;

--- a/test-utils/data-helpers.ts
+++ b/test-utils/data-helpers.ts
@@ -8,7 +8,9 @@ export interface SupabaseChainableMock extends Record<string, Mock> {
   delete: Mock;
   eq: Mock;
   gt: Mock;
+  gte: Mock;
   lt: Mock;
+  lte: Mock;
   single: Mock;
   order: Mock;
   or: Mock;
@@ -17,9 +19,11 @@ export interface SupabaseChainableMock extends Record<string, Mock> {
 
 export const buildSupabaseChainableMock = (): SupabaseChainableMock => {
   const chain: Record<string, Mock> = {};
-  ['select', 'insert', 'update', 'delete', 'eq', 'gt', 'lt', 'single', 'order', 'or', 'limit'].forEach((method) => {
-    chain[method] = vi.fn().mockReturnValue(chain);
-  });
+  ['select', 'insert', 'update', 'delete', 'eq', 'gt', 'gte', 'lt', 'lte', 'single', 'order', 'or', 'limit'].forEach(
+    (method) => {
+      chain[method] = vi.fn().mockReturnValue(chain);
+    },
+  );
   return chain as SupabaseChainableMock;
 };
 

--- a/test-utils/data-helpers.ts
+++ b/test-utils/data-helpers.ts
@@ -1,12 +1,26 @@
 import { createClient } from '@/utils/supabase/server';
 import { type Mock, vi } from 'vitest';
 
-export const buildChainableMock = () => {
+export interface SupabaseChainableMock extends Record<string, Mock> {
+  select: Mock;
+  insert: Mock;
+  update: Mock;
+  delete: Mock;
+  eq: Mock;
+  gt: Mock;
+  lt: Mock;
+  single: Mock;
+  order: Mock;
+  or: Mock;
+  limit: Mock;
+}
+
+export const buildSupabaseChainableMock = (): SupabaseChainableMock => {
   const chain: Record<string, Mock> = {};
   ['select', 'insert', 'update', 'delete', 'eq', 'gt', 'lt', 'single', 'order', 'or', 'limit'].forEach((method) => {
     chain[method] = vi.fn().mockReturnValue(chain);
   });
-  return chain;
+  return chain as SupabaseChainableMock;
 };
 
 export const setLoggedOut = () => {


### PR DESCRIPTION
Update dashboard event fetching logic to display key upcoming events and limit prior events to the last week, utilizing a new `effective_end_date` function for consistent queries. Relates to #65.