### PR TITLE
Enhance card component link tests

### DIFF
--- a/app/adventure/events/ui/__tests__/event-card.spec.tsx
+++ b/app/adventure/events/ui/__tests__/event-card.spec.tsx
@@ -1,14 +1,9 @@
 import { PLACES } from '@/app/adventure/places/__mocks__/data';
 import { Event } from '@/models';
 import { cleanup, render, screen } from '@testing-library/react';
-import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { EVENT_TYPES } from '../../__mocks__/data';
 import EventCard from '../event-card';
-
-vi.mock('next/link', () => ({
-  default: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
-}));
 
 describe('Event Card', () => {
   beforeEach(() => vi.clearAllMocks());

--- a/app/adventure/notes/ui/__tests__/note-card.spec.tsx
+++ b/app/adventure/notes/ui/__tests__/note-card.spec.tsx
@@ -32,7 +32,7 @@ describe('Note Card', () => {
   });
 
   describe('delete link', () => {
-    it('links to the delete page for the collection', () => {
+    it('links to the delete page for the note', () => {
       render(<NoteCard baseHref={`/adventure/event/${TEST_NOTE.eventRid}/notes`} note={TEST_NOTE} />);
       const link = screen.getByRole('button', { name: /delete/i }).closest('a');
       expect(link?.getAttribute('href')).toBe(`/adventure/event/${TEST_NOTE.eventRid}/notes/${TEST_NOTE.id}/delete`);
@@ -40,7 +40,7 @@ describe('Note Card', () => {
   });
 
   describe('edit link', () => {
-    it('links to the update page for the event', () => {
+    it('links to the update page for the note', () => {
       render(<NoteCard baseHref={`/adventure/event/${TEST_NOTE.eventRid}/notes`} note={TEST_NOTE} />);
       const link = screen.getByRole('button', { name: /edit/i }).closest('a');
       expect(link?.getAttribute('href')).toBe(`/adventure/event/${TEST_NOTE.eventRid}/notes/${TEST_NOTE.id}/update`);

--- a/app/adventure/notes/ui/__tests__/note-card.spec.tsx
+++ b/app/adventure/notes/ui/__tests__/note-card.spec.tsx
@@ -1,9 +1,13 @@
 import { Note } from '@/models';
 import { cleanup, render, screen } from '@testing-library/react';
+import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import NoteCard from '../note-card';
 
 vi.mock('../../data');
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
+}));
 
 describe('Note Card', () => {
   beforeEach(() => vi.clearAllMocks());
@@ -25,6 +29,22 @@ describe('Note Card', () => {
     expect(links.length).toBe(2);
     expect(links[0]).toHaveProperty('href', expect.stringMatching(/\/7314159\/delete$/));
     expect(links[1]).toHaveProperty('href', expect.stringMatching(/\/7314159\/update$/));
+  });
+
+  describe('delete link', () => {
+    it('links to the delete page for the collection', () => {
+      render(<NoteCard baseHref={`/adventure/event/${TEST_NOTE.eventRid}/notes`} note={TEST_NOTE} />);
+      const link = screen.getByRole('button', { name: /delete/i }).closest('a');
+      expect(link?.getAttribute('href')).toBe(`/adventure/event/${TEST_NOTE.eventRid}/notes/${TEST_NOTE.id}/delete`);
+    });
+  });
+
+  describe('edit link', () => {
+    it('links to the update page for the event', () => {
+      render(<NoteCard baseHref={`/adventure/event/${TEST_NOTE.eventRid}/notes`} note={TEST_NOTE} />);
+      const link = screen.getByRole('button', { name: /edit/i }).closest('a');
+      expect(link?.getAttribute('href')).toBe(`/adventure/event/${TEST_NOTE.eventRid}/notes/${TEST_NOTE.id}/update`);
+    });
   });
 });
 

--- a/app/adventure/notes/ui/__tests__/note-card.spec.tsx
+++ b/app/adventure/notes/ui/__tests__/note-card.spec.tsx
@@ -4,7 +4,6 @@ import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import NoteCard from '../note-card';
 
-vi.mock('../../data');
 vi.mock('next/link', () => ({
   default: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
 }));

--- a/app/adventure/notes/ui/__tests__/note-card.spec.tsx
+++ b/app/adventure/notes/ui/__tests__/note-card.spec.tsx
@@ -1,12 +1,7 @@
 import { Note } from '@/models';
 import { cleanup, render, screen } from '@testing-library/react';
-import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import NoteCard from '../note-card';
-
-vi.mock('next/link', () => ({
-  default: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
-}));
 
 describe('Note Card', () => {
   beforeEach(() => vi.clearAllMocks());

--- a/app/adventure/notes/ui/__tests__/note-card.spec.tsx
+++ b/app/adventure/notes/ui/__tests__/note-card.spec.tsx
@@ -22,14 +22,6 @@ describe('Note Card', () => {
     expect(screen.getByText(TEST_NOTE.description!)).toBeDefined();
   });
 
-  it('includes delete and update links', () => {
-    render(<NoteCard baseHref={`/adventure/event/${TEST_NOTE.eventRid}/notes`} note={TEST_NOTE} />);
-    const links = screen.queryAllByRole('link');
-    expect(links.length).toBe(2);
-    expect(links[0]).toHaveProperty('href', expect.stringMatching(/\/7314159\/delete$/));
-    expect(links[1]).toHaveProperty('href', expect.stringMatching(/\/7314159\/update$/));
-  });
-
   describe('delete link', () => {
     it('links to the delete page for the note', () => {
       render(<NoteCard baseHref={`/adventure/event/${TEST_NOTE.eventRid}/notes`} note={TEST_NOTE} />);

--- a/app/adventure/todos/ui/__tests__/todo-collection-card.spec.tsx
+++ b/app/adventure/todos/ui/__tests__/todo-collection-card.spec.tsx
@@ -18,64 +18,34 @@ describe('TODO Collection Card', () => {
   afterEach(() => cleanup());
 
   it('renders the title', () => {
-    render(
-      <TodoCollectionCard
-        baseHref={`/adventure/todos/${TEST_COLLECTION.id}/update`}
-        todoCollection={TEST_COLLECTION}
-      />,
-    );
+    render(<TodoCollectionCard baseHref={'/adventure/todos'} todoCollection={TEST_COLLECTION} />);
     expect(screen.getByRole('heading', { level: 3, name: TEST_COLLECTION.name })).toBeDefined();
   });
 
   it('renders the due date if the collection has one', () => {
-    render(
-      <TodoCollectionCard
-        baseHref={`/adventure/todos/${TEST_COLLECTION.id}/update`}
-        todoCollection={TEST_COLLECTION}
-      />,
-    );
+    render(<TodoCollectionCard baseHref={'/adventure/todos'} todoCollection={TEST_COLLECTION} />);
     expect(screen.getByText('Due Date:')).toBeDefined();
     expect(screen.getByText('Mar 17, 2025')).toBeDefined();
   });
 
   it('does not render the due date if the collection does not have one', () => {
-    render(
-      <TodoCollectionCard
-        baseHref={`/adventure/todos/${TEST_COLLECTION.id}/update`}
-        todoCollection={{ ...TEST_COLLECTION, dueDate: null }}
-      />,
-    );
+    render(<TodoCollectionCard baseHref={'/adventure/todos'} todoCollection={{ ...TEST_COLLECTION, dueDate: null }} />);
     expect(screen.queryByText('Due Date:')).toBeNull();
   });
 
   it('renders the description', () => {
-    render(
-      <TodoCollectionCard
-        baseHref={`/adventure/todos/${TEST_COLLECTION.id}/update`}
-        todoCollection={TEST_COLLECTION}
-      />,
-    );
+    render(<TodoCollectionCard baseHref={'/adventure/todos'} todoCollection={TEST_COLLECTION} />);
     expect(screen.getByText(TEST_COLLECTION.description!)).toBeDefined();
   });
 
   it('renders the todo items', () => {
-    render(
-      <TodoCollectionCard
-        baseHref={`/adventure/todos/${TEST_COLLECTION.id}/update`}
-        todoCollection={TEST_COLLECTION}
-      />,
-    );
+    render(<TodoCollectionCard baseHref={'/adventure/todos'} todoCollection={TEST_COLLECTION} />);
     const items = screen.getByTestId('todo-items');
     expect(within(items).getAllByRole('checkbox').length).toEqual(TEST_COLLECTION.todoItems.length);
   });
 
   it('renders the open items first, completed items last', () => {
-    render(
-      <TodoCollectionCard
-        baseHref={`/adventure/todos/${TEST_COLLECTION.id}/update`}
-        todoCollection={TEST_COLLECTION}
-      />,
-    );
+    render(<TodoCollectionCard baseHref={'/adventure/todos'} todoCollection={TEST_COLLECTION} />);
     const elements = screen.getAllByRole('checkbox');
     expect(elements[0].parentElement!.textContent).toEqual('Test the fetching');
     expect(elements[1].parentElement!.textContent).toEqual('Create an item');
@@ -108,12 +78,7 @@ describe('TODO Collection Card', () => {
   it('allows the user to update todo item text', async () => {
     const item = TEST_COLLECTION.todoItems.find((x) => x.name === 'Fetch the data');
     const user = userEvent.setup();
-    render(
-      <TodoCollectionCard
-        baseHref={`/adventure/todos/${TEST_COLLECTION.id}/update`}
-        todoCollection={TEST_COLLECTION}
-      />,
-    );
+    render(<TodoCollectionCard baseHref={'/adventure/todos'} todoCollection={TEST_COLLECTION} />);
     await user.click(screen.getByText('Fetch the data'));
     await user.type(screen.getByRole('textbox'), ' and do something with it');
     await user.click(screen.getByTestId('save-button'));
@@ -126,12 +91,7 @@ describe('TODO Collection Card', () => {
   it('allows items to be checked', async () => {
     const item = TEST_COLLECTION.todoItems.find((x) => x.name === 'Create an item');
     const user = userEvent.setup();
-    render(
-      <TodoCollectionCard
-        baseHref={`/adventure/todos/${TEST_COLLECTION.id}/update`}
-        todoCollection={TEST_COLLECTION}
-      />,
-    );
+    render(<TodoCollectionCard baseHref={'/adventure/todos'} todoCollection={TEST_COLLECTION} />);
     const elements = screen.getAllByRole('checkbox');
     await user.click(elements[1]);
     expect(updateTodoItem).toHaveBeenCalledExactlyOnceWith({
@@ -143,12 +103,7 @@ describe('TODO Collection Card', () => {
   it('allows items to be unchecked', async () => {
     const item = TEST_COLLECTION.todoItems.find((x) => x.name === 'Fetch the data');
     const user = userEvent.setup();
-    render(
-      <TodoCollectionCard
-        baseHref={`/adventure/todos/${TEST_COLLECTION.id}/update`}
-        todoCollection={TEST_COLLECTION}
-      />,
-    );
+    render(<TodoCollectionCard baseHref={'/adventure/todos'} todoCollection={TEST_COLLECTION} />);
     const elements = screen.getAllByRole('checkbox');
     await user.click(elements[2]);
     expect(updateTodoItem).toHaveBeenCalledExactlyOnceWith({
@@ -188,12 +143,7 @@ describe('TODO Collection Card', () => {
   describe('add button', () => {
     it('adds a new TODO', async () => {
       const user = userEvent.setup();
-      render(
-        <TodoCollectionCard
-          baseHref={`/adventure/todos/${TEST_COLLECTION.id}/update`}
-          todoCollection={TEST_COLLECTION}
-        />,
-      );
+      render(<TodoCollectionCard baseHref={'/adventure/todos'} todoCollection={TEST_COLLECTION} />);
       await user.click(screen.getByRole('button', { name: 'Add new Todo Item' }));
       expect(addTodoItem).toHaveBeenCalledExactlyOnceWith({ isComplete: false, name: '', todoCollectionRid: 7314159 });
     });
@@ -201,12 +151,7 @@ describe('TODO Collection Card', () => {
     it('displays the new TODO', async () => {
       (addTodoItem as Mock).mockResolvedValue({ id: 932, name: '', todoCollectionRid: 7314159, isComplete: false });
       const user = userEvent.setup();
-      render(
-        <TodoCollectionCard
-          baseHref={`/adventure/todos/${TEST_COLLECTION.id}/update`}
-          todoCollection={TEST_COLLECTION}
-        />,
-      );
+      render(<TodoCollectionCard baseHref={'/adventure/todos'} todoCollection={TEST_COLLECTION} />);
       await user.click(screen.getByRole('button', { name: 'Add new Todo Item' }));
       const items = screen.getByTestId('todo-items');
       expect(within(items).getAllByRole('checkbox').length).toEqual(TEST_COLLECTION.todoItems.length + 1);

--- a/app/adventure/todos/ui/__tests__/todo-collection-card.spec.tsx
+++ b/app/adventure/todos/ui/__tests__/todo-collection-card.spec.tsx
@@ -6,8 +6,12 @@ import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 import { addTodoItem, updateTodoItem } from '../../data';
 import TodoCollectionCard from '../todo-collection-card';
 import { EVENTS } from '@/app/adventure/events/__mocks__/data';
+import React from 'react';
 
 vi.mock('../../data');
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
+}));
 
 describe('TODO Collection Card', () => {
   beforeEach(() => vi.clearAllMocks());

--- a/app/adventure/todos/ui/__tests__/todo-collection-card.spec.tsx
+++ b/app/adventure/todos/ui/__tests__/todo-collection-card.spec.tsx
@@ -127,7 +127,7 @@ describe('TODO Collection Card', () => {
   });
 
   describe('edit link', () => {
-    it('links to the update page for the event', () => {
+    it('links to the update page for the collection', () => {
       render(<TodoCollectionCard baseHref={'/adventure/todos'} todoCollection={TEST_COLLECTION} callingPage="Home" />);
       const link = screen.getByRole('button', { name: /edit/i }).closest('a');
       expect(link?.getAttribute('href')).toBe(`/adventure/todos/${TEST_COLLECTION.id}/update?callingPage=Home`);

--- a/app/adventure/todos/ui/__tests__/todo-collection-card.spec.tsx
+++ b/app/adventure/todos/ui/__tests__/todo-collection-card.spec.tsx
@@ -1,12 +1,12 @@
 import { EQUIPMENT } from '@/app/adventure/equipment/__mocks__/data';
+import { EVENTS } from '@/app/adventure/events/__mocks__/data';
 import { TodoCollection } from '@/models';
 import { cleanup, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 import { addTodoItem, updateTodoItem } from '../../data';
 import TodoCollectionCard from '../todo-collection-card';
-import { EVENTS } from '@/app/adventure/events/__mocks__/data';
-import React from 'react';
 
 vi.mock('../../data');
 vi.mock('next/link', () => ({
@@ -98,7 +98,7 @@ describe('TODO Collection Card', () => {
       expect(screen.getByText(EVENTS[0].name)).toBeDefined();
     });
 
-    it('does not display an assoication if there is not one', () => {
+    it('does not display an association if there is not one', () => {
       render(<TodoCollectionCard baseHref="/adventure/todos" todoCollection={TEST_COLLECTION} />);
       expect(screen.queryByText('For Equipment:')).toBeNull();
       expect(screen.queryByText('For Event:')).toBeNull();
@@ -154,6 +154,34 @@ describe('TODO Collection Card', () => {
     expect(updateTodoItem).toHaveBeenCalledExactlyOnceWith({
       ...item,
       isComplete: false,
+    });
+  });
+
+  describe('delete link', () => {
+    it('links to the delete page for the collection', () => {
+      render(<TodoCollectionCard baseHref={'/adventure/todos'} todoCollection={TEST_COLLECTION} callingPage="Home" />);
+      const link = screen.getByRole('button', { name: /delete/i }).closest('a');
+      expect(link?.getAttribute('href')).toBe(`/adventure/todos/${TEST_COLLECTION.id}/delete?callingPage=Home`);
+    });
+
+    it('does not include the search parameter when callingPage is not provided', () => {
+      render(<TodoCollectionCard baseHref={'/adventure/todos'} todoCollection={TEST_COLLECTION} />);
+      const link = screen.getByRole('button', { name: /delete/i }).closest('a');
+      expect(link?.getAttribute('href')).toBe(`/adventure/todos/${TEST_COLLECTION.id}/delete`);
+    });
+  });
+
+  describe('edit link', () => {
+    it('links to the update page for the event', () => {
+      render(<TodoCollectionCard baseHref={'/adventure/todos'} todoCollection={TEST_COLLECTION} callingPage="Home" />);
+      const link = screen.getByRole('button', { name: /edit/i }).closest('a');
+      expect(link?.getAttribute('href')).toBe(`/adventure/todos/${TEST_COLLECTION.id}/update?callingPage=Home`);
+    });
+
+    it('does not include the search parameter when callingPage is not provided', () => {
+      render(<TodoCollectionCard baseHref={'/adventure/todos'} todoCollection={TEST_COLLECTION} />);
+      const link = screen.getByRole('button', { name: /edit/i }).closest('a');
+      expect(link?.getAttribute('href')).toBe(`/adventure/todos/${TEST_COLLECTION.id}/update`);
     });
   });
 

--- a/app/adventure/todos/ui/__tests__/todo-collection-card.spec.tsx
+++ b/app/adventure/todos/ui/__tests__/todo-collection-card.spec.tsx
@@ -3,15 +3,11 @@ import { EVENTS } from '@/app/adventure/events/__mocks__/data';
 import { TodoCollection } from '@/models';
 import { cleanup, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 import { addTodoItem, updateTodoItem } from '../../data';
 import TodoCollectionCard from '../todo-collection-card';
 
 vi.mock('../../data');
-vi.mock('next/link', () => ({
-  default: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
-}));
 
 describe('TODO Collection Card', () => {
   beforeEach(() => vi.clearAllMocks());


### PR DESCRIPTION
Add tests for `NoteCard` and `TodoCollectionCard` to verify accurate edit and delete link navigation, including query parameters. Mock `next/link` for robust component testing.