### PR TITLE
Refactor Dashboard event display

### DIFF
--- a/app/adventure/__tests__/dashboard.spec.tsx
+++ b/app/adventure/__tests__/dashboard.spec.tsx
@@ -18,6 +18,7 @@ describe('dashboard component', () => {
     it('displays the events', () => {
       render(<Dashboard currentEvents={EVENTS} recentPastEvents={[]} dueTodoCollections={[]} />);
       EVENTS.forEach((e) => expect(screen.getByRole('link', { name: e.name })));
+      expect(screen.getAllByRole('heading', { level: 3 })).toHaveLength(EVENTS.length);
     });
 
     it('does not display a no events message', () => {
@@ -53,6 +54,7 @@ describe('dashboard component', () => {
       expect(screen.getByRole('link', { name: EVENTS[0].name }));
       expect(screen.getByRole('link', { name: EVENTS[2].name }));
       expect(screen.getByRole('link', { name: EVENTS[3].name }));
+      expect(screen.getAllByRole('heading', { level: 3 })).toHaveLength(3);
     });
 
     it('does not display a no events message', () => {
@@ -64,14 +66,14 @@ describe('dashboard component', () => {
   });
 
   describe('without recently created events', () => {
-    it('displays the "Recent Past Events" header', () => {
+    it('does not display the "Recent Past Events" header', () => {
       render(<Dashboard currentEvents={[]} recentPastEvents={[]} dueTodoCollections={[]} />);
-      expect(screen.getByRole('heading', { name: 'Recent Past Events', level: 2 })).toBeDefined();
+      expect(screen.queryByRole('heading', { name: 'Recent Past Events', level: 2 })).toBeNull();
     });
 
-    it('displays a no events message', () => {
+    it('does not display a no events message', () => {
       render(<Dashboard currentEvents={[]} recentPastEvents={[]} dueTodoCollections={[]} />);
-      expect(screen.getByText('You have no events.')).toBeDefined();
+      expect(screen.queryByText('You have no events.')).toBeNull();
     });
   });
 

--- a/app/adventure/__tests__/dashboard.spec.tsx
+++ b/app/adventure/__tests__/dashboard.spec.tsx
@@ -11,84 +11,90 @@ describe('dashboard component', () => {
 
   describe('with current events', () => {
     it('displays the "Upcoming Trips & Events" header', () => {
-      render(<Dashboard currentEvents={EVENTS} latestEvents={[]} dueTodoCollections={[]} />);
+      render(<Dashboard currentEvents={EVENTS} recentPastEvents={[]} dueTodoCollections={[]} />);
       expect(screen.getByRole('heading', { name: 'Upcoming Events', level: 2 })).toBeDefined();
     });
 
     it('displays the events', () => {
-      render(<Dashboard currentEvents={EVENTS} latestEvents={[]} dueTodoCollections={[]} />);
+      render(<Dashboard currentEvents={EVENTS} recentPastEvents={[]} dueTodoCollections={[]} />);
       EVENTS.forEach((e) => expect(screen.getByRole('link', { name: e.name })));
     });
 
     it('does not display a no events message', () => {
-      render(<Dashboard currentEvents={EVENTS} latestEvents={[]} dueTodoCollections={[]} />);
+      render(<Dashboard currentEvents={EVENTS} recentPastEvents={[]} dueTodoCollections={[]} />);
       expect(screen.queryByText('You have no upcoming events.')).toBeNull();
     });
   });
 
   describe('without current events', () => {
     it('displays the "Upcoming Events" header', () => {
-      render(<Dashboard currentEvents={[]} latestEvents={[]} dueTodoCollections={[]} />);
+      render(<Dashboard currentEvents={[]} recentPastEvents={[]} dueTodoCollections={[]} />);
       expect(screen.getByRole('heading', { name: 'Upcoming Events', level: 2 })).toBeDefined();
     });
 
     it('displays a no events message', () => {
-      render(<Dashboard currentEvents={[]} latestEvents={[]} dueTodoCollections={[]} />);
+      render(<Dashboard currentEvents={[]} recentPastEvents={[]} dueTodoCollections={[]} />);
       expect(screen.getByText('You have no upcoming events.')).toBeDefined();
     });
   });
 
   describe('with recently created events', () => {
     it('displays the "Most Recent Events" header', () => {
-      render(<Dashboard currentEvents={[]} latestEvents={[EVENTS[0], EVENTS[2], EVENTS[3]]} dueTodoCollections={[]} />);
+      render(
+        <Dashboard currentEvents={[]} recentPastEvents={[EVENTS[0], EVENTS[2], EVENTS[3]]} dueTodoCollections={[]} />,
+      );
       expect(screen.getByRole('heading', { name: 'Most Recent Events', level: 2 })).toBeDefined();
     });
 
     it('displays the events', () => {
-      render(<Dashboard currentEvents={[]} latestEvents={[EVENTS[0], EVENTS[2], EVENTS[3]]} dueTodoCollections={[]} />);
+      render(
+        <Dashboard currentEvents={[]} recentPastEvents={[EVENTS[0], EVENTS[2], EVENTS[3]]} dueTodoCollections={[]} />,
+      );
       expect(screen.getByRole('link', { name: EVENTS[0].name }));
       expect(screen.getByRole('link', { name: EVENTS[2].name }));
       expect(screen.getByRole('link', { name: EVENTS[3].name }));
     });
 
     it('does not display a no events message', () => {
-      render(<Dashboard currentEvents={[]} latestEvents={[EVENTS[0], EVENTS[2], EVENTS[3]]} dueTodoCollections={[]} />);
+      render(
+        <Dashboard currentEvents={[]} recentPastEvents={[EVENTS[0], EVENTS[2], EVENTS[3]]} dueTodoCollections={[]} />,
+      );
       expect(screen.queryByText('You have no events.')).toBeNull();
     });
   });
 
   describe('without recently created events', () => {
     it('displays the "Most Recent Events" header', () => {
-      render(<Dashboard currentEvents={[]} latestEvents={[]} dueTodoCollections={[]} />);
+      render(<Dashboard currentEvents={[]} recentPastEvents={[]} dueTodoCollections={[]} />);
       expect(screen.getByRole('heading', { name: 'Most Recent Events', level: 2 })).toBeDefined();
     });
 
     it('displays a no events message', () => {
-      render(<Dashboard currentEvents={[]} latestEvents={[]} dueTodoCollections={[]} />);
+      render(<Dashboard currentEvents={[]} recentPastEvents={[]} dueTodoCollections={[]} />);
       expect(screen.getByText('You have no events.')).toBeDefined();
     });
   });
 
   describe('with due todo collections', () => {
     it('displays the "Most Recent Events" header', () => {
-      render(<Dashboard currentEvents={[]} latestEvents={[]} dueTodoCollections={TODO_COLLECTIONS} />);
+      render(<Dashboard currentEvents={[]} recentPastEvents={[]} dueTodoCollections={TODO_COLLECTIONS} />);
       expect(screen.getByRole('heading', { name: 'Due TODOs', level: 2 })).toBeDefined();
     });
 
     it('does not display a no TODOs message', () => {
-      render(<Dashboard currentEvents={[]} latestEvents={[]} dueTodoCollections={TODO_COLLECTIONS} />);
+      render(<Dashboard currentEvents={[]} recentPastEvents={[]} dueTodoCollections={TODO_COLLECTIONS} />);
       expect(screen.queryByText('You have no TODOs due at this time.')).toBeNull();
     });
   });
 
   describe('without due todo collections', () => {
     it('displays the "Most Recent Events" header', () => {
-      render(<Dashboard currentEvents={[]} latestEvents={[]} dueTodoCollections={[]} />);
+      render(<Dashboard currentEvents={[]} recentPastEvents={[]} dueTodoCollections={[]} />);
       expect(screen.getByRole('heading', { name: 'Due TODOs', level: 2 })).toBeDefined();
     });
 
     it('displays a no TODOs message', () => {
-      render(<Dashboard currentEvents={[]} latestEvents={[]} dueTodoCollections={[]} />);
+      render(<Dashboard currentEvents={[]} recentPastEvents={[]} dueTodoCollections={[]} />);
       expect(screen.getByText('You have no TODOs due at this time.')).toBeDefined();
     });
   });

--- a/app/adventure/__tests__/dashboard.spec.tsx
+++ b/app/adventure/__tests__/dashboard.spec.tsx
@@ -39,11 +39,11 @@ describe('dashboard component', () => {
   });
 
   describe('with recently created events', () => {
-    it('displays the "Most Recent Events" header', () => {
+    it('displays the "Recent Past Events" header', () => {
       render(
         <Dashboard currentEvents={[]} recentPastEvents={[EVENTS[0], EVENTS[2], EVENTS[3]]} dueTodoCollections={[]} />,
       );
-      expect(screen.getByRole('heading', { name: 'Most Recent Events', level: 2 })).toBeDefined();
+      expect(screen.getByRole('heading', { name: 'Recent Past Events', level: 2 })).toBeDefined();
     });
 
     it('displays the events', () => {
@@ -64,9 +64,9 @@ describe('dashboard component', () => {
   });
 
   describe('without recently created events', () => {
-    it('displays the "Most Recent Events" header', () => {
+    it('displays the "Recent Past Events" header', () => {
       render(<Dashboard currentEvents={[]} recentPastEvents={[]} dueTodoCollections={[]} />);
-      expect(screen.getByRole('heading', { name: 'Most Recent Events', level: 2 })).toBeDefined();
+      expect(screen.getByRole('heading', { name: 'Recent Past Events', level: 2 })).toBeDefined();
     });
 
     it('displays a no events message', () => {
@@ -76,7 +76,7 @@ describe('dashboard component', () => {
   });
 
   describe('with due todo collections', () => {
-    it('displays the "Most Recent Events" header', () => {
+    it('displays the "Due TODOs" header', () => {
       render(<Dashboard currentEvents={[]} recentPastEvents={[]} dueTodoCollections={TODO_COLLECTIONS} />);
       expect(screen.getByRole('heading', { name: 'Due TODOs', level: 2 })).toBeDefined();
     });
@@ -88,7 +88,7 @@ describe('dashboard component', () => {
   });
 
   describe('without due todo collections', () => {
-    it('displays the "Most Recent Events" header', () => {
+    it('displays the "Due TODOs" header', () => {
       render(<Dashboard currentEvents={[]} recentPastEvents={[]} dueTodoCollections={[]} />);
       expect(screen.getByRole('heading', { name: 'Due TODOs', level: 2 })).toBeDefined();
     });

--- a/app/adventure/dashboard.tsx
+++ b/app/adventure/dashboard.tsx
@@ -7,11 +7,11 @@ import Todos from './todos/ui/todos';
 
 interface DashboardProps {
   currentEvents: Event[];
-  latestEvents: Event[];
+  recentPastEvents: Event[];
   dueTodoCollections: TodoCollection[];
 }
 
-const Dashboard = ({ currentEvents, dueTodoCollections, latestEvents }: DashboardProps) => {
+const Dashboard = ({ currentEvents, dueTodoCollections, recentPastEvents }: DashboardProps) => {
   return (
     <>
       <section>
@@ -33,9 +33,9 @@ const Dashboard = ({ currentEvents, dueTodoCollections, latestEvents }: Dashboar
         <SectionHeader>
           <SubtitleHeading>Most Recent Events</SubtitleHeading>
         </SectionHeader>
-        {latestEvents.length ? (
+        {recentPastEvents.length ? (
           <div className="grid gap-2 grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 ">
-            {latestEvents.map((x) => (
+            {recentPastEvents.map((x) => (
               <EventCard event={x} key={x.id} callingPage="Home" />
             ))}
           </div>

--- a/app/adventure/dashboard.tsx
+++ b/app/adventure/dashboard.tsx
@@ -29,20 +29,18 @@ const Dashboard = ({ currentEvents, dueTodoCollections, recentPastEvents }: Dash
         )}
       </section>
 
-      <section>
-        <SectionHeader>
-          <SubtitleHeading>Recent Past Events</SubtitleHeading>
-        </SectionHeader>
-        {recentPastEvents.length ? (
+      {recentPastEvents.length ? (
+        <section>
+          <SectionHeader>
+            <SubtitleHeading>Recent Past Events</SubtitleHeading>
+          </SectionHeader>
           <div className="grid gap-2 grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 ">
             {recentPastEvents.map((x) => (
               <EventCard event={x} key={x.id} callingPage="Home" />
             ))}
           </div>
-        ) : (
-          <Message>You have no events.</Message>
-        )}
-      </section>
+        </section>
+      ) : null}
 
       <section>
         <SectionHeader>

--- a/app/adventure/dashboard.tsx
+++ b/app/adventure/dashboard.tsx
@@ -1,11 +1,9 @@
 import SectionHeader from '@/app/ui/section-header';
 import SubtitleHeading from '@/app/ui/subtitle-heading';
 import { Event, TodoCollection } from '@/models';
-import EventsTable from '@/app/adventure/events/events-table';
-import EventsList from '@/app/adventure/events/events-list';
-import Todos from './todos/ui/todos';
 import Message from '../ui/message';
-// import EventCard from './events/ui/event-card';
+import EventCard from './events/ui/event-card';
+import Todos from './todos/ui/todos';
 
 interface DashboardProps {
   currentEvents: Event[];
@@ -21,39 +19,26 @@ const Dashboard = ({ currentEvents, dueTodoCollections, latestEvents }: Dashboar
           <SubtitleHeading>Upcoming Events</SubtitleHeading>
         </SectionHeader>
         {currentEvents.length ? (
-          <>
-            <EventsTable className="hidden md:table" events={currentEvents} callingPage="Home" />
-            <EventsList className="block md:hidden" events={currentEvents} callingPage="Home" />
-          </>
-        ) : (
-          <Message>You have no upcoming events.</Message>
-        )}
-      </section>
-
-      {/* <section>
-        <SectionHeader>
-          <SubtitleHeading>Have a look</SubtitleHeading>
-        </SectionHeader>
-        {currentEvents.length ? (
           <div className="grid gap-2 grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 ">
             {currentEvents.map((x) => (
               <EventCard event={x} key={x.id} callingPage="Home" />
             ))}
           </div>
         ) : (
-          <Message>You have no events in this timeframe.</Message>
+          <Message>You have no upcoming events.</Message>
         )}
-      </section> */}
+      </section>
 
       <section>
         <SectionHeader>
           <SubtitleHeading>Most Recent Events</SubtitleHeading>
         </SectionHeader>
         {latestEvents.length ? (
-          <>
-            <EventsTable className="hidden md:table" events={latestEvents} callingPage="Home" />
-            <EventsList className="block md:hidden" events={latestEvents} callingPage="Home" />
-          </>
+          <div className="grid gap-2 grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 ">
+            {latestEvents.map((x) => (
+              <EventCard event={x} key={x.id} callingPage="Home" />
+            ))}
+          </div>
         ) : (
           <Message>You have no events.</Message>
         )}

--- a/app/adventure/dashboard.tsx
+++ b/app/adventure/dashboard.tsx
@@ -31,7 +31,7 @@ const Dashboard = ({ currentEvents, dueTodoCollections, recentPastEvents }: Dash
 
       <section>
         <SectionHeader>
-          <SubtitleHeading>Most Recent Events</SubtitleHeading>
+          <SubtitleHeading>Recent Past Events</SubtitleHeading>
         </SectionHeader>
         {recentPastEvents.length ? (
           <div className="grid gap-2 grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 ">

--- a/app/adventure/page.tsx
+++ b/app/adventure/page.tsx
@@ -15,7 +15,7 @@ const getHomePageData = async () => {
   const now = new Date();
 
   const allEvents = await fetchUpcomingEvents(dateToString(now));
-  const latestEvents = await fetchPriorEvents(dateToString(now), dateToString(addWeeks(now, -1)));
+  const pastEvents = await fetchPriorEvents(dateToString(now), dateToString(addWeeks(now, -1)));
   const todoCollections = await fetchDueTodoCollections(dateToString(addWeeks(now, 1)));
 
   let currentEvents = filterCurrentEvents(allEvents, dateToString(addWeeks(now, 2)));
@@ -23,18 +23,18 @@ const getHomePageData = async () => {
     currentEvents = firstThreeEvents(allEvents);
   }
 
-  return { currentEvents, latestEvents, todoCollections };
+  return { currentEvents, pastEvents, todoCollections };
 };
 
 const HomePage = async () => {
-  const { currentEvents, latestEvents, todoCollections } = await getHomePageData();
+  const { currentEvents, pastEvents, todoCollections } = await getHomePageData();
 
   return (
     <>
       <PageHeader>
         <TitleHeading>Dashboard</TitleHeading>
       </PageHeader>
-      <Dashboard currentEvents={currentEvents} latestEvents={latestEvents} dueTodoCollections={todoCollections} />
+      <Dashboard currentEvents={currentEvents} recentPastEvents={pastEvents} dueTodoCollections={todoCollections} />
     </>
   );
 };


### PR DESCRIPTION
Refactor the Dashboard to use `EventCard` components for events, replacing list views with a card-based layout. Rename `latestEvents` to `recentPastEvents` for improved clarity. Relates to #68.