### PR TITLE
Add persistent 'Show All' toggles for events

### DIFF
--- a/.changeset/three-worms-stay.md
+++ b/.changeset/three-worms-stay.md
@@ -1,0 +1,5 @@
+---
+'recreation-planner': patch
+---
+
+Add "show all" checkboxes for upcoming and prior events.

--- a/app/adventure/events/__tests__/actions.spec.ts
+++ b/app/adventure/events/__tests__/actions.spec.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setShowAllPriorEvents, setShowAllUpcomingEvents } from '../actions';
+import { cookies } from 'next/headers';
+import { revalidatePath } from 'next/cache';
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn().mockResolvedValue({ set: vi.fn() }),
+}));
+
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }));
+
+describe('Events Actions', () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.clearAllMocks());
+
+  describe('setShowAllUpcomingEvents', () => {
+    it('sets the show-all-upcoming-events cookie to true when called with true', async () => {
+      const cookieStore = await cookies();
+      await setShowAllUpcomingEvents(true);
+      expect(cookieStore.set).toHaveBeenCalledWith('show-all-upcoming-events', 'true');
+    });
+
+    it('sets the show-all-upcoming-events cookie to false when called with false', async () => {
+      const cookieStore = await cookies();
+      await setShowAllUpcomingEvents(false);
+      expect(cookieStore.set).toHaveBeenCalledWith('show-all-upcoming-events', 'false');
+    });
+
+    it('calls revalidatePath for the events page', async () => {
+      await setShowAllUpcomingEvents(true);
+      expect(revalidatePath).toHaveBeenCalledWith('/adventure/events');
+    });
+  });
+
+  describe('setShowAllPriorEvents', () => {
+    it('sets the show-all-prior-events cookie to true when called with true', async () => {
+      const cookieStore = await cookies();
+      await setShowAllPriorEvents(true);
+      expect(cookieStore.set).toHaveBeenCalledWith('show-all-prior-events', 'true');
+    });
+
+    it('sets the show-all-prior-events cookie to false when called with false', async () => {
+      const cookieStore = await cookies();
+      await setShowAllPriorEvents(false);
+      expect(cookieStore.set).toHaveBeenCalledWith('show-all-prior-events', 'false');
+    });
+
+    it('calls revalidatePath for the events page', async () => {
+      await setShowAllPriorEvents(true);
+      expect(revalidatePath).toHaveBeenCalledWith('/adventure/events');
+    });
+  });
+});

--- a/app/adventure/events/__tests__/actions.spec.ts
+++ b/app/adventure/events/__tests__/actions.spec.ts
@@ -17,18 +17,22 @@ describe('Events Actions', () => {
     it('sets the show-all-upcoming-events cookie to true when called with true', async () => {
       const cookieStore = await cookies();
       await setShowAllUpcomingEvents(true);
-      expect(cookieStore.set).toHaveBeenCalledWith('show-all-upcoming-events', 'true');
+      expect(cookieStore.set).toHaveBeenCalledExactlyOnceWith('show-all-upcoming-events', 'true', {
+        maxAge: 60 * 60 * 24 * 365,
+      });
     });
 
     it('sets the show-all-upcoming-events cookie to false when called with false', async () => {
       const cookieStore = await cookies();
       await setShowAllUpcomingEvents(false);
-      expect(cookieStore.set).toHaveBeenCalledWith('show-all-upcoming-events', 'false');
+      expect(cookieStore.set).toHaveBeenCalledExactlyOnceWith('show-all-upcoming-events', 'false', {
+        maxAge: 60 * 60 * 24 * 365,
+      });
     });
 
     it('calls revalidatePath for the events page', async () => {
       await setShowAllUpcomingEvents(true);
-      expect(revalidatePath).toHaveBeenCalledWith('/adventure/events');
+      expect(revalidatePath).toHaveBeenCalledExactlyOnceWith('/adventure/events');
     });
   });
 
@@ -36,18 +40,22 @@ describe('Events Actions', () => {
     it('sets the show-all-prior-events cookie to true when called with true', async () => {
       const cookieStore = await cookies();
       await setShowAllPriorEvents(true);
-      expect(cookieStore.set).toHaveBeenCalledWith('show-all-prior-events', 'true');
+      expect(cookieStore.set).toHaveBeenCalledExactlyOnceWith('show-all-prior-events', 'true', {
+        maxAge: 60 * 60 * 24 * 365,
+      });
     });
 
     it('sets the show-all-prior-events cookie to false when called with false', async () => {
       const cookieStore = await cookies();
       await setShowAllPriorEvents(false);
-      expect(cookieStore.set).toHaveBeenCalledWith('show-all-prior-events', 'false');
+      expect(cookieStore.set).toHaveBeenCalledExactlyOnceWith('show-all-prior-events', 'false', {
+        maxAge: 60 * 60 * 24 * 365,
+      });
     });
 
     it('calls revalidatePath for the events page', async () => {
       await setShowAllPriorEvents(true);
-      expect(revalidatePath).toHaveBeenCalledWith('/adventure/events');
+      expect(revalidatePath).toHaveBeenCalledExactlyOnceWith('/adventure/events');
     });
   });
 });

--- a/app/adventure/events/__tests__/events.spec.tsx
+++ b/app/adventure/events/__tests__/events.spec.tsx
@@ -57,5 +57,45 @@ describe('Events', () => {
       const checkboxes = screen.getAllByLabelText('Show All', { selector: 'input[type="checkbox"]' });
       expect(checkboxes.length).toBeGreaterThanOrEqual(2);
     });
+
+    describe('upcoming events Show All checkbox', () => {
+      it('is unchecked by default when showAllUpcomingEvents is not provided', () => {
+        render(<Events upcomingEvents={EVENTS} priorEvents={[]} />);
+        const checkboxes = screen.getAllByLabelText('Show All', { selector: 'input[type="checkbox"]' });
+        expect((checkboxes[0] as HTMLInputElement).checked).toBe(false);
+      });
+
+      it('is checked when showAllUpcomingEvents is true', () => {
+        render(<Events upcomingEvents={EVENTS} priorEvents={[]} showAllUpcomingEvents={true} />);
+        const checkboxes = screen.getAllByLabelText('Show All', { selector: 'input[type="checkbox"]' });
+        expect((checkboxes[0] as HTMLInputElement).checked).toBe(true);
+      });
+
+      it('is unchecked when showAllUpcomingEvents is false', () => {
+        render(<Events upcomingEvents={EVENTS} priorEvents={[]} showAllUpcomingEvents={false} />);
+        const checkboxes = screen.getAllByLabelText('Show All', { selector: 'input[type="checkbox"]' });
+        expect((checkboxes[0] as HTMLInputElement).checked).toBe(false);
+      });
+    });
+
+    describe('prior events Show All checkbox', () => {
+      it('is unchecked by default when showAllPriorEvents is not provided', () => {
+        render(<Events upcomingEvents={[]} priorEvents={EVENTS} />);
+        const checkboxes = screen.getAllByLabelText('Show All', { selector: 'input[type="checkbox"]' });
+        expect((checkboxes[1] as HTMLInputElement).checked).toBe(false);
+      });
+
+      it('is checked when showAllPriorEvents is true', () => {
+        render(<Events upcomingEvents={[]} priorEvents={EVENTS} showAllPriorEvents={true} />);
+        const checkboxes = screen.getAllByLabelText('Show All', { selector: 'input[type="checkbox"]' });
+        expect((checkboxes[1] as HTMLInputElement).checked).toBe(true);
+      });
+
+      it('is unchecked when showAllPriorEvents is false', () => {
+        render(<Events upcomingEvents={[]} priorEvents={EVENTS} showAllPriorEvents={false} />);
+        const checkboxes = screen.getAllByLabelText('Show All', { selector: 'input[type="checkbox"]' });
+        expect((checkboxes[1] as HTMLInputElement).checked).toBe(false);
+      });
+    });
   });
 });

--- a/app/adventure/events/__tests__/events.spec.tsx
+++ b/app/adventure/events/__tests__/events.spec.tsx
@@ -4,8 +4,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { EVENTS } from '../__mocks__/data';
 import Events from '../events';
 
-vi.mock('../events-list', () => ({ default: () => <div data-testid="events-list" /> }));
-vi.mock('../events-table', () => ({ default: () => <div data-testid="events-table" /> }));
 vi.mock('../ui/event-card', () => ({
   default: ({ event }: { event: { name: string } }) => <div data-testid="event-card">{event.name}</div>,
 }));

--- a/app/adventure/events/__tests__/events.spec.tsx
+++ b/app/adventure/events/__tests__/events.spec.tsx
@@ -1,4 +1,5 @@
 import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { EVENTS } from '../__mocks__/data';
 import Events from '../events';
@@ -95,6 +96,68 @@ describe('Events', () => {
         render(<Events upcomingEvents={[]} priorEvents={EVENTS} showAllPriorEvents={false} />);
         const checkboxes = screen.getAllByLabelText('Show All', { selector: 'input[type="checkbox"]' });
         expect((checkboxes[1] as HTMLInputElement).checked).toBe(false);
+      });
+    });
+
+    describe('interactions', () => {
+      it('calls onShowAllUpcomingEventsChange with true when the upcoming Show All checkbox is clicked', async () => {
+        const onShowAllUpcomingEventsChange = vi.fn();
+        const user = userEvent.setup();
+        render(
+          <Events
+            upcomingEvents={EVENTS}
+            priorEvents={EVENTS}
+            onShowAllUpcomingEventsChange={onShowAllUpcomingEventsChange}
+          />,
+        );
+        const checkboxes = screen.getAllByLabelText('Show All', { selector: 'input[type="checkbox"]' });
+        await user.click(checkboxes[0]);
+        expect(onShowAllUpcomingEventsChange).toHaveBeenCalledExactlyOnceWith(true);
+      });
+
+      it('calls onShowAllPriorEventsChange with true when the prior Show All checkbox is clicked', async () => {
+        const onShowAllPriorEventsChange = vi.fn();
+        const user = userEvent.setup();
+        render(
+          <Events
+            upcomingEvents={EVENTS}
+            priorEvents={EVENTS}
+            onShowAllPriorEventsChange={onShowAllPriorEventsChange}
+          />,
+        );
+        const checkboxes = screen.getAllByLabelText('Show All', { selector: 'input[type="checkbox"]' });
+        await user.click(checkboxes[1]);
+        expect(onShowAllPriorEventsChange).toHaveBeenCalledExactlyOnceWith(true);
+      });
+
+      it('does not call onShowAllPriorEventsChange when the upcoming Show All checkbox is clicked', async () => {
+        const onShowAllPriorEventsChange = vi.fn();
+        const user = userEvent.setup();
+        render(
+          <Events
+            upcomingEvents={EVENTS}
+            priorEvents={EVENTS}
+            onShowAllPriorEventsChange={onShowAllPriorEventsChange}
+          />,
+        );
+        const checkboxes = screen.getAllByLabelText('Show All', { selector: 'input[type="checkbox"]' });
+        await user.click(checkboxes[0]);
+        expect(onShowAllPriorEventsChange).not.toHaveBeenCalled();
+      });
+
+      it('does not call onShowAllUpcomingEventsChange when the prior Show All checkbox is clicked', async () => {
+        const onShowAllUpcomingEventsChange = vi.fn();
+        const user = userEvent.setup();
+        render(
+          <Events
+            upcomingEvents={EVENTS}
+            priorEvents={EVENTS}
+            onShowAllUpcomingEventsChange={onShowAllUpcomingEventsChange}
+          />,
+        );
+        const checkboxes = screen.getAllByLabelText('Show All', { selector: 'input[type="checkbox"]' });
+        await user.click(checkboxes[1]);
+        expect(onShowAllUpcomingEventsChange).not.toHaveBeenCalled();
       });
     });
   });

--- a/app/adventure/events/__tests__/events.spec.tsx
+++ b/app/adventure/events/__tests__/events.spec.tsx
@@ -70,4 +70,24 @@ describe('Events', () => {
       expect(screen.queryByRole('heading', { name: 'Prior Trips & Events' })).toBeNull();
     });
   });
+
+  describe('Show All checkboxes', () => {
+    it('renders a Show All checkbox for upcoming events section', () => {
+      render(<Events upcomingEvents={EVENTS} priorEvents={[]} />);
+      const checkboxes = screen.getAllByLabelText('Show All', { selector: 'input[type="checkbox"]' });
+      expect(checkboxes.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('renders a Show All checkbox for prior events section', () => {
+      render(<Events upcomingEvents={[]} priorEvents={EVENTS} />);
+      const checkboxes = screen.getAllByLabelText('Show All', { selector: 'input[type="checkbox"]' });
+      expect(checkboxes.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('renders two Show All checkboxes when both sections are present', () => {
+      render(<Events upcomingEvents={EVENTS} priorEvents={EVENTS} />);
+      const checkboxes = screen.getAllByLabelText('Show All', { selector: 'input[type="checkbox"]' });
+      expect(checkboxes.length).toBeGreaterThanOrEqual(2);
+    });
+  });
 });

--- a/app/adventure/events/__tests__/events.spec.tsx
+++ b/app/adventure/events/__tests__/events.spec.tsx
@@ -13,7 +13,7 @@ describe('Events', () => {
   beforeEach(() => vi.clearAllMocks());
   afterEach(() => cleanup());
 
-  describe('with upcoming events', () => {
+  describe('upcoming events', () => {
     it('renders the "Upcoming Trips & Events" section heading', () => {
       render(<Events upcomingEvents={EVENTS} priorEvents={[]} />);
       expect(screen.getByRole('heading', { name: 'Upcoming Trips & Events' })).toBeDefined();
@@ -25,18 +25,14 @@ describe('Events', () => {
       expect(cards).toHaveLength(EVENTS.length);
     });
 
-    it('does not render the events list', () => {
-      render(<Events upcomingEvents={EVENTS} priorEvents={[]} />);
-      expect(screen.queryByTestId('events-list')).toBeNull();
-    });
-
-    it('does not render the events table', () => {
-      render(<Events upcomingEvents={EVENTS} priorEvents={[]} />);
-      expect(screen.queryByTestId('events-table')).toBeNull();
+    it('displays a no events message', () => {
+      render(<Events upcomingEvents={[]} priorEvents={EVENTS} />);
+      expect(screen.getByRole('heading', { name: 'Upcoming Trips & Events' })).toBeDefined();
+      expect(screen.getByText('You have no upcoming events.')).toBeDefined();
     });
   });
 
-  describe('with prior events', () => {
+  describe('prior events', () => {
     it('renders the "Prior Trips & Events" section heading', () => {
       render(<Events upcomingEvents={[]} priorEvents={EVENTS} />);
       expect(screen.getByRole('heading', { name: 'Prior Trips & Events' })).toBeDefined();
@@ -48,44 +44,16 @@ describe('Events', () => {
       expect(cards).toHaveLength(EVENTS.length);
     });
 
-    it('does not render the events list', () => {
-      render(<Events upcomingEvents={[]} priorEvents={EVENTS} />);
-      expect(screen.queryByTestId('events-list')).toBeNull();
-    });
-
-    it('does not render the events table', () => {
-      render(<Events upcomingEvents={[]} priorEvents={EVENTS} />);
-      expect(screen.queryByTestId('events-table')).toBeNull();
-    });
-  });
-
-  describe('with no events', () => {
-    it('does not render the upcoming section', () => {
-      render(<Events upcomingEvents={[]} priorEvents={[]} />);
-      expect(screen.queryByRole('heading', { name: 'Upcoming Trips & Events' })).toBeNull();
-    });
-
-    it('does not render the prior section', () => {
-      render(<Events upcomingEvents={[]} priorEvents={[]} />);
-      expect(screen.queryByRole('heading', { name: 'Prior Trips & Events' })).toBeNull();
+    it('displays a no events message', () => {
+      render(<Events upcomingEvents={EVENTS} priorEvents={[]} />);
+      expect(screen.getByRole('heading', { name: 'Prior Trips & Events' })).toBeDefined();
+      expect(screen.getByText('You have no prior events.')).toBeDefined();
     });
   });
 
   describe('Show All checkboxes', () => {
-    it('renders a Show All checkbox for upcoming events section', () => {
-      render(<Events upcomingEvents={EVENTS} priorEvents={[]} />);
-      const checkboxes = screen.getAllByLabelText('Show All', { selector: 'input[type="checkbox"]' });
-      expect(checkboxes.length).toBeGreaterThanOrEqual(1);
-    });
-
-    it('renders a Show All checkbox for prior events section', () => {
-      render(<Events upcomingEvents={[]} priorEvents={EVENTS} />);
-      const checkboxes = screen.getAllByLabelText('Show All', { selector: 'input[type="checkbox"]' });
-      expect(checkboxes.length).toBeGreaterThanOrEqual(1);
-    });
-
     it('renders two Show All checkboxes when both sections are present', () => {
-      render(<Events upcomingEvents={EVENTS} priorEvents={EVENTS} />);
+      render(<Events upcomingEvents={[]} priorEvents={[]} />);
       const checkboxes = screen.getAllByLabelText('Show All', { selector: 'input[type="checkbox"]' });
       expect(checkboxes.length).toBeGreaterThanOrEqual(2);
     });

--- a/app/adventure/events/__tests__/page.spec.tsx
+++ b/app/adventure/events/__tests__/page.spec.tsx
@@ -14,7 +14,7 @@ describe('Events Page', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.clearAllMocks();
-    vi.mocked(cookies).mockResolvedValue({ get: vi.fn() } as unknown as ReturnType<typeof cookies>);
+    vi.mocked(cookies).mockResolvedValue({ get: vi.fn() } as unknown as Awaited<ReturnType<typeof cookies>>);
   });
 
   afterEach(() => {

--- a/app/adventure/events/__tests__/page.spec.tsx
+++ b/app/adventure/events/__tests__/page.spec.tsx
@@ -1,6 +1,8 @@
 import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { cookies } from 'next/headers';
 import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
+import { setShowAllPriorEvents, setShowAllUpcomingEvents } from '../actions';
 import { fetchPriorEvents, fetchUpcomingEvents } from '../data';
 import EventsPage from '../page';
 
@@ -12,6 +14,7 @@ describe('Events Page', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.clearAllMocks();
+    vi.mocked(cookies).mockResolvedValue({ get: vi.fn() } as unknown as ReturnType<typeof cookies>);
   });
 
   afterEach(() => {
@@ -112,6 +115,54 @@ describe('Events Page', () => {
       render(jsx);
       const checkboxes = screen.getAllByLabelText('Show All', { selector: 'input[type="checkbox"]' });
       expect((checkboxes[1] as HTMLInputElement).checked).toBe(true);
+    });
+  });
+
+  describe('action wiring', () => {
+    beforeEach(() => vi.useRealTimers());
+
+    it('calls setShowAllUpcomingEvents(true) when the upcoming Show All checkbox is clicked', async () => {
+      const user = userEvent.setup();
+      const jsx = await EventsPage();
+      render(jsx);
+      const checkboxes = screen.getAllByLabelText('Show All', { selector: 'input[type="checkbox"]' });
+      await user.click(checkboxes[0]);
+      expect(setShowAllUpcomingEvents).toHaveBeenCalledExactlyOnceWith(true);
+    });
+
+    it('calls setShowAllPriorEvents(true) when the prior Show All checkbox is clicked', async () => {
+      const user = userEvent.setup();
+      const jsx = await EventsPage();
+      render(jsx);
+      const checkboxes = screen.getAllByLabelText('Show All', { selector: 'input[type="checkbox"]' });
+      await user.click(checkboxes[1]);
+      expect(setShowAllPriorEvents).toHaveBeenCalledExactlyOnceWith(true);
+    });
+
+    it('calls setShowAllUpcomingEvents(false) when the upcoming Show All checkbox is unchecked', async () => {
+      const cookieStore = await cookies();
+      (cookieStore.get as Mock).mockImplementation((name: string) =>
+        name === 'show-all-upcoming-events' ? { value: 'true' } : undefined,
+      );
+      const user = userEvent.setup();
+      const jsx = await EventsPage();
+      render(jsx);
+      const checkboxes = screen.getAllByLabelText('Show All', { selector: 'input[type="checkbox"]' });
+      await user.click(checkboxes[0]);
+      expect(setShowAllUpcomingEvents).toHaveBeenCalledExactlyOnceWith(false);
+    });
+
+    it('calls setShowAllPriorEvents(false) when the prior Show All checkbox is unchecked', async () => {
+      const cookieStore = await cookies();
+      (cookieStore.get as Mock).mockImplementation((name: string) =>
+        name === 'show-all-prior-events' ? { value: 'true' } : undefined,
+      );
+      const user = userEvent.setup();
+      const jsx = await EventsPage();
+      render(jsx);
+      const checkboxes = screen.getAllByLabelText('Show All', { selector: 'input[type="checkbox"]' });
+      await user.click(checkboxes[1]);
+      expect(setShowAllPriorEvents).toHaveBeenCalledExactlyOnceWith(false);
     });
   });
 });

--- a/app/adventure/events/__tests__/page.spec.tsx
+++ b/app/adventure/events/__tests__/page.spec.tsx
@@ -1,9 +1,12 @@
 import { cleanup, render, screen } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cookies } from 'next/headers';
+import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 import { fetchPriorEvents, fetchUpcomingEvents } from '../data';
 import EventsPage from '../page';
 
 vi.mock('../data');
+vi.mock('../actions');
+vi.mock('next/headers', () => ({ cookies: vi.fn().mockResolvedValue({ get: vi.fn() }) }));
 
 describe('Events Page', () => {
   beforeEach(() => {
@@ -32,5 +35,83 @@ describe('Events Page', () => {
     const jsx = await EventsPage();
     render(jsx);
     expect(screen.getByRole('heading', { level: 1, name: 'Trips & Events' })).toBeDefined();
+  });
+
+  describe('show all upcoming events', () => {
+    it('fetches all upcoming events when the show-all-upcoming-events cookie is true', async () => {
+      const cookieStore = await cookies();
+      vi.setSystemTime(new Date(2024, 10, 27));
+      (cookieStore.get as Mock).mockImplementation((name: string) =>
+        name === 'show-all-upcoming-events' ? { value: 'true' } : undefined,
+      );
+      await EventsPage();
+      expect(fetchUpcomingEvents).toHaveBeenCalledExactlyOnceWith('2024-11-24');
+    });
+
+    it('fetches bounded upcoming events when the show-all-upcoming-events cookie is false', async () => {
+      const cookieStore = await cookies();
+      vi.setSystemTime(new Date(2024, 10, 27));
+      (cookieStore.get as Mock).mockImplementation((name: string) =>
+        name === 'show-all-upcoming-events' ? { value: 'false' } : undefined,
+      );
+      await EventsPage();
+      expect(fetchUpcomingEvents).toHaveBeenCalledExactlyOnceWith('2024-11-24', '2025-02-24');
+    });
+
+    it('fetches bounded upcoming events when the show-all-upcoming-events cookie is absent', async () => {
+      vi.setSystemTime(new Date(2024, 10, 27));
+      await EventsPage();
+      expect(fetchUpcomingEvents).toHaveBeenCalledExactlyOnceWith('2024-11-24', '2025-02-24');
+    });
+
+    it('renders the upcoming Show All checkbox as checked when the cookie is true', async () => {
+      const cookieStore = await cookies();
+      (cookieStore.get as Mock).mockImplementation((name: string) =>
+        name === 'show-all-upcoming-events' ? { value: 'true' } : undefined,
+      );
+      const jsx = await EventsPage();
+      render(jsx);
+      const checkboxes = screen.getAllByLabelText('Show All', { selector: 'input[type="checkbox"]' });
+      expect((checkboxes[0] as HTMLInputElement).checked).toBe(true);
+    });
+  });
+
+  describe('show all prior events', () => {
+    it('fetches all prior events when the show-all-prior-events cookie is true', async () => {
+      const cookieStore = await cookies();
+      vi.setSystemTime(new Date(2024, 10, 27));
+      (cookieStore.get as Mock).mockImplementation((name: string) =>
+        name === 'show-all-prior-events' ? { value: 'true' } : undefined,
+      );
+      await EventsPage();
+      expect(fetchPriorEvents).toHaveBeenCalledExactlyOnceWith('2024-11-24');
+    });
+
+    it('fetches bounded prior events when the show-all-prior-events cookie is false', async () => {
+      const cookieStore = await cookies();
+      vi.setSystemTime(new Date(2024, 10, 27));
+      (cookieStore.get as Mock).mockImplementation((name: string) =>
+        name === 'show-all-prior-events' ? { value: 'false' } : undefined,
+      );
+      await EventsPage();
+      expect(fetchPriorEvents).toHaveBeenCalledExactlyOnceWith('2024-11-24', '2024-10-24');
+    });
+
+    it('fetches bounded prior events when the show-all-prior-events cookie is absent', async () => {
+      vi.setSystemTime(new Date(2024, 10, 27));
+      await EventsPage();
+      expect(fetchPriorEvents).toHaveBeenCalledExactlyOnceWith('2024-11-24', '2024-10-24');
+    });
+
+    it('renders the prior Show All checkbox as checked when the cookie is true', async () => {
+      const cookieStore = await cookies();
+      (cookieStore.get as Mock).mockImplementation((name: string) =>
+        name === 'show-all-prior-events' ? { value: 'true' } : undefined,
+      );
+      const jsx = await EventsPage();
+      render(jsx);
+      const checkboxes = screen.getAllByLabelText('Show All', { selector: 'input[type="checkbox"]' });
+      expect((checkboxes[1] as HTMLInputElement).checked).toBe(true);
+    });
   });
 });

--- a/app/adventure/events/actions.ts
+++ b/app/adventure/events/actions.ts
@@ -1,0 +1,16 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { cookies } from 'next/headers';
+
+export const setShowAllUpcomingEvents = async (showAll: boolean) => {
+  const cookieStore = await cookies();
+  cookieStore.set('show-all-upcoming-events', showAll ? 'true' : 'false');
+  revalidatePath('/adventure/events');
+};
+
+export const setShowAllPriorEvents = async (showAll: boolean) => {
+  const cookieStore = await cookies();
+  cookieStore.set('show-all-prior-events', showAll ? 'true' : 'false');
+  revalidatePath('/adventure/events');
+};

--- a/app/adventure/events/actions.ts
+++ b/app/adventure/events/actions.ts
@@ -3,14 +3,20 @@
 import { revalidatePath } from 'next/cache';
 import { cookies } from 'next/headers';
 
+const ONE_YEAR_IN_SECONDS = 60 * 60 * 24 * 365;
+
 export const setShowAllUpcomingEvents = async (showAll: boolean) => {
   const cookieStore = await cookies();
-  cookieStore.set('show-all-upcoming-events', showAll ? 'true' : 'false');
+  cookieStore.set('show-all-upcoming-events', showAll ? 'true' : 'false', {
+    maxAge: ONE_YEAR_IN_SECONDS,
+  });
   revalidatePath('/adventure/events');
 };
 
 export const setShowAllPriorEvents = async (showAll: boolean) => {
   const cookieStore = await cookies();
-  cookieStore.set('show-all-prior-events', showAll ? 'true' : 'false');
+  cookieStore.set('show-all-prior-events', showAll ? 'true' : 'false', {
+    maxAge: ONE_YEAR_IN_SECONDS,
+  });
   revalidatePath('/adventure/events');
 };

--- a/app/adventure/events/events.tsx
+++ b/app/adventure/events/events.tsx
@@ -9,9 +9,18 @@ interface EventsProperties {
   upcomingEvents: Array<Event>;
   showAllPriorEvents?: boolean;
   showAllUpcomingEvents?: boolean;
+  onShowAllPriorEventsChange?: (showAll: boolean) => void;
+  onShowAllUpcomingEventsChange?: (showAll: boolean) => void;
 }
 
-const Events = ({ priorEvents, upcomingEvents, showAllPriorEvents, showAllUpcomingEvents }: EventsProperties) => {
+const Events = ({
+  priorEvents,
+  upcomingEvents,
+  showAllPriorEvents,
+  showAllUpcomingEvents,
+  onShowAllPriorEventsChange,
+  onShowAllUpcomingEventsChange,
+}: EventsProperties) => {
   return (
     <>
       <section>
@@ -19,7 +28,12 @@ const Events = ({ priorEvents, upcomingEvents, showAllPriorEvents, showAllUpcomi
           <div className="flex items-center justify-between w-full">
             <SubtitleHeading>Upcoming Trips &amp; Events</SubtitleHeading>
             <label className="flex items-center gap-2 cursor-pointer select-none">
-              <input type="checkbox" className="checkbox checkbox-sm" defaultChecked={showAllUpcomingEvents} />
+              <input
+                type="checkbox"
+                className="checkbox checkbox-sm"
+                defaultChecked={showAllUpcomingEvents}
+                onChange={(e) => onShowAllUpcomingEventsChange?.(e.target.checked)}
+              />
               <span className="text-sm">Show All</span>
             </label>
           </div>
@@ -39,7 +53,12 @@ const Events = ({ priorEvents, upcomingEvents, showAllPriorEvents, showAllUpcomi
           <div className="flex items-center justify-between w-full">
             <SubtitleHeading>Prior Trips &amp; Events</SubtitleHeading>
             <label className="flex items-center gap-2 cursor-pointer select-none">
-              <input type="checkbox" className="checkbox checkbox-sm" defaultChecked={showAllPriorEvents} />
+              <input
+                type="checkbox"
+                className="checkbox checkbox-sm"
+                defaultChecked={showAllPriorEvents}
+                onChange={(e) => onShowAllPriorEventsChange?.(e.target.checked)}
+              />
               <span className="text-sm">Show All</span>
             </label>
           </div>

--- a/app/adventure/events/events.tsx
+++ b/app/adventure/events/events.tsx
@@ -11,7 +11,7 @@ interface EventsProperties {
   showAllUpcomingEvents?: boolean;
 }
 
-const Events = ({ priorEvents, upcomingEvents }: EventsProperties) => {
+const Events = ({ priorEvents, upcomingEvents, showAllPriorEvents, showAllUpcomingEvents }: EventsProperties) => {
   return (
     <>
       <section>
@@ -19,7 +19,7 @@ const Events = ({ priorEvents, upcomingEvents }: EventsProperties) => {
           <div className="flex items-center justify-between w-full">
             <SubtitleHeading>Upcoming Trips &amp; Events</SubtitleHeading>
             <label className="flex items-center gap-2 cursor-pointer select-none">
-              <input type="checkbox" className="checkbox checkbox-sm" />
+              <input type="checkbox" className="checkbox checkbox-sm" defaultChecked={showAllUpcomingEvents} />
               <span className="text-sm">Show All</span>
             </label>
           </div>
@@ -39,7 +39,7 @@ const Events = ({ priorEvents, upcomingEvents }: EventsProperties) => {
           <div className="flex items-center justify-between w-full">
             <SubtitleHeading>Prior Trips &amp; Events</SubtitleHeading>
             <label className="flex items-center gap-2 cursor-pointer select-none">
-              <input type="checkbox" className="checkbox checkbox-sm" />
+              <input type="checkbox" className="checkbox checkbox-sm" defaultChecked={showAllPriorEvents} />
               <span className="text-sm">Show All</span>
             </label>
           </div>

--- a/app/adventure/events/events.tsx
+++ b/app/adventure/events/events.tsx
@@ -6,6 +6,8 @@ import EventCard from './ui/event-card';
 interface EventsProperties {
   priorEvents: Array<Event>;
   upcomingEvents: Array<Event>;
+  showAllPriorEvents?: boolean;
+  showAllUpcomingEvents?: boolean;
 }
 
 const Events = ({ priorEvents, upcomingEvents }: EventsProperties) => {
@@ -14,7 +16,13 @@ const Events = ({ priorEvents, upcomingEvents }: EventsProperties) => {
       {upcomingEvents.length ? (
         <section>
           <SectionHeader>
-            <SubtitleHeading>Upcoming Trips &amp; Events</SubtitleHeading>
+            <div className="flex items-center justify-between w-full">
+              <SubtitleHeading>Upcoming Trips &amp; Events</SubtitleHeading>
+              <label className="flex items-center gap-2 cursor-pointer select-none">
+                <input type="checkbox" className="checkbox checkbox-sm" />
+                <span className="text-sm">Show All</span>
+              </label>
+            </div>
           </SectionHeader>
           <div className="grid gap-2 grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 ">
             {upcomingEvents.map((x) => (
@@ -26,7 +34,13 @@ const Events = ({ priorEvents, upcomingEvents }: EventsProperties) => {
       {priorEvents.length ? (
         <section>
           <SectionHeader>
-            <SubtitleHeading>Prior Trips &amp; Events</SubtitleHeading>
+            <div className="flex items-center justify-between w-full">
+              <SubtitleHeading>Prior Trips &amp; Events</SubtitleHeading>
+              <label className="flex items-center gap-2 cursor-pointer select-none">
+                <input type="checkbox" className="checkbox checkbox-sm" />
+                <span className="text-sm">Show All</span>
+              </label>
+            </div>
           </SectionHeader>
           <div className="grid gap-2 grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 ">
             {priorEvents.map((x) => (

--- a/app/adventure/events/events.tsx
+++ b/app/adventure/events/events.tsx
@@ -2,6 +2,7 @@ import SectionHeader from '@/app/ui/section-header';
 import SubtitleHeading from '@/app/ui/subtitle-heading';
 import { Event } from '@/models';
 import EventCard from './ui/event-card';
+import ShowAllToggle from './ui/show-all-toggle';
 import Message from '@/app/ui/message';
 
 interface EventsProperties {
@@ -27,15 +28,7 @@ const Events = ({
         <SectionHeader>
           <div className="flex items-center justify-between w-full">
             <SubtitleHeading>Upcoming Trips &amp; Events</SubtitleHeading>
-            <label className="flex items-center gap-2 cursor-pointer select-none">
-              <input
-                type="checkbox"
-                className="checkbox checkbox-sm"
-                defaultChecked={showAllUpcomingEvents}
-                onChange={(e) => onShowAllUpcomingEventsChange?.(e.target.checked)}
-              />
-              <span className="text-sm">Show All</span>
-            </label>
+            <ShowAllToggle checked={showAllUpcomingEvents} onChange={onShowAllUpcomingEventsChange} />
           </div>
         </SectionHeader>
         {upcomingEvents.length ? (
@@ -52,15 +45,7 @@ const Events = ({
         <SectionHeader>
           <div className="flex items-center justify-between w-full">
             <SubtitleHeading>Prior Trips &amp; Events</SubtitleHeading>
-            <label className="flex items-center gap-2 cursor-pointer select-none">
-              <input
-                type="checkbox"
-                className="checkbox checkbox-sm"
-                defaultChecked={showAllPriorEvents}
-                onChange={(e) => onShowAllPriorEventsChange?.(e.target.checked)}
-              />
-              <span className="text-sm">Show All</span>
-            </label>
+            <ShowAllToggle checked={showAllPriorEvents} onChange={onShowAllPriorEventsChange} />
           </div>
         </SectionHeader>
         {priorEvents.length ? (

--- a/app/adventure/events/events.tsx
+++ b/app/adventure/events/events.tsx
@@ -2,6 +2,7 @@ import SectionHeader from '@/app/ui/section-header';
 import SubtitleHeading from '@/app/ui/subtitle-heading';
 import { Event } from '@/models';
 import EventCard from './ui/event-card';
+import Message from '@/app/ui/message';
 
 interface EventsProperties {
   priorEvents: Array<Event>;
@@ -13,42 +14,46 @@ interface EventsProperties {
 const Events = ({ priorEvents, upcomingEvents }: EventsProperties) => {
   return (
     <>
-      {upcomingEvents.length ? (
-        <section>
-          <SectionHeader>
-            <div className="flex items-center justify-between w-full">
-              <SubtitleHeading>Upcoming Trips &amp; Events</SubtitleHeading>
-              <label className="flex items-center gap-2 cursor-pointer select-none">
-                <input type="checkbox" className="checkbox checkbox-sm" />
-                <span className="text-sm">Show All</span>
-              </label>
-            </div>
-          </SectionHeader>
+      <section>
+        <SectionHeader>
+          <div className="flex items-center justify-between w-full">
+            <SubtitleHeading>Upcoming Trips &amp; Events</SubtitleHeading>
+            <label className="flex items-center gap-2 cursor-pointer select-none">
+              <input type="checkbox" className="checkbox checkbox-sm" />
+              <span className="text-sm">Show All</span>
+            </label>
+          </div>
+        </SectionHeader>
+        {upcomingEvents.length ? (
           <div className="grid gap-2 grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 ">
             {upcomingEvents.map((x) => (
               <EventCard event={x} key={x.id} callingPage="Events" />
             ))}
           </div>
-        </section>
-      ) : undefined}
-      {priorEvents.length ? (
-        <section>
-          <SectionHeader>
-            <div className="flex items-center justify-between w-full">
-              <SubtitleHeading>Prior Trips &amp; Events</SubtitleHeading>
-              <label className="flex items-center gap-2 cursor-pointer select-none">
-                <input type="checkbox" className="checkbox checkbox-sm" />
-                <span className="text-sm">Show All</span>
-              </label>
-            </div>
-          </SectionHeader>
+        ) : (
+          <Message>You have no upcoming events.</Message>
+        )}
+      </section>
+      <section>
+        <SectionHeader>
+          <div className="flex items-center justify-between w-full">
+            <SubtitleHeading>Prior Trips &amp; Events</SubtitleHeading>
+            <label className="flex items-center gap-2 cursor-pointer select-none">
+              <input type="checkbox" className="checkbox checkbox-sm" />
+              <span className="text-sm">Show All</span>
+            </label>
+          </div>
+        </SectionHeader>
+        {priorEvents.length ? (
           <div className="grid gap-2 grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 ">
             {priorEvents.map((x) => (
               <EventCard event={x} key={x.id} callingPage="Events" />
             ))}
           </div>
-        </section>
-      ) : undefined}
+        ) : (
+          <Message>You have no prior events.</Message>
+        )}
+      </section>
     </>
   );
 };

--- a/app/adventure/events/page.tsx
+++ b/app/adventure/events/page.tsx
@@ -5,25 +5,36 @@ import { addMonths, formatISO, startOfWeek } from 'date-fns';
 import Link from 'next/link';
 import { fetchPriorEvents, fetchUpcomingEvents } from './data';
 import Events from './events';
+import { cookies } from 'next/headers';
 
 const getEventsPageData = async () => {
+  const cookieStore = await cookies();
+  const showAllUpcomingEvents = cookieStore.get('show-all-upcoming-events')?.value === 'true';
+  const showAllPriorEvents = cookieStore.get('show-all-prior-events')?.value === 'true';
+
   const dt = formatISO(startOfWeek(Date.now()), { representation: 'date' });
   const endDate = formatISO(addMonths(startOfWeek(Date.now()), 3), { representation: 'date' });
   const afterDate = formatISO(addMonths(startOfWeek(Date.now()), -1), { representation: 'date' });
-  const upcomingEvents = await fetchUpcomingEvents(dt, endDate);
-  const priorEvents = await fetchPriorEvents(dt, afterDate);
-  return { upcomingEvents, priorEvents };
+
+  const upcomingEvents = await (showAllUpcomingEvents ? fetchUpcomingEvents(dt) : fetchUpcomingEvents(dt, endDate));
+  const priorEvents = await (showAllPriorEvents ? fetchPriorEvents(dt) : fetchPriorEvents(dt, afterDate));
+  return { upcomingEvents, priorEvents, showAllPriorEvents, showAllUpcomingEvents };
 };
 
 const EventsPage = async () => {
-  const { upcomingEvents, priorEvents } = await getEventsPageData();
+  const { upcomingEvents, priorEvents, showAllUpcomingEvents, showAllPriorEvents } = await getEventsPageData();
 
   return (
     <>
       <PageHeader>
         <TitleHeading>Trips &amp; Events</TitleHeading>
       </PageHeader>
-      <Events priorEvents={priorEvents} upcomingEvents={upcomingEvents} />
+      <Events
+        priorEvents={priorEvents}
+        upcomingEvents={upcomingEvents}
+        showAllUpcomingEvents={showAllUpcomingEvents}
+        showAllPriorEvents={showAllPriorEvents}
+      />
       <Link className="fixed bottom-4 right-4" href="/adventure/events/create">
         <button className="btn btn-primary btn-circle btn-outline">
           <PlusIcon className="w-6" />

--- a/app/adventure/events/page.tsx
+++ b/app/adventure/events/page.tsx
@@ -2,10 +2,11 @@ import PageHeader from '@/app/ui/page-header';
 import TitleHeading from '@/app/ui/title-heading';
 import { PlusIcon } from '@heroicons/react/24/outline';
 import { addMonths, formatISO, startOfWeek } from 'date-fns';
+import { cookies } from 'next/headers';
 import Link from 'next/link';
+import { setShowAllPriorEvents, setShowAllUpcomingEvents } from './actions';
 import { fetchPriorEvents, fetchUpcomingEvents } from './data';
 import Events from './events';
-import { cookies } from 'next/headers';
 
 const getEventsPageData = async () => {
   const cookieStore = await cookies();
@@ -34,6 +35,8 @@ const EventsPage = async () => {
         upcomingEvents={upcomingEvents}
         showAllUpcomingEvents={showAllUpcomingEvents}
         showAllPriorEvents={showAllPriorEvents}
+        onShowAllUpcomingEventsChange={setShowAllUpcomingEvents}
+        onShowAllPriorEventsChange={setShowAllPriorEvents}
       />
       <Link className="fixed bottom-4 right-4" href="/adventure/events/create">
         <button className="btn btn-primary btn-circle btn-outline">

--- a/app/adventure/events/ui/__tests__/show-all-toggle.spec.tsx
+++ b/app/adventure/events/ui/__tests__/show-all-toggle.spec.tsx
@@ -1,0 +1,48 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import ShowAllToggle from '../show-all-toggle';
+
+describe('ShowAllToggle', () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => cleanup());
+
+  it('renders the checkbox', () => {
+    render(<ShowAllToggle onChange={vi.fn()} />);
+    expect(screen.getByRole('checkbox')).toBeDefined();
+  });
+
+  it('renders the "Show All" label', () => {
+    render(<ShowAllToggle onChange={vi.fn()} />);
+    expect(screen.getByText('Show All')).toBeDefined();
+  });
+
+  it('renders the checkbox as unchecked when checked is false', () => {
+    render(<ShowAllToggle checked={false} onChange={vi.fn()} />);
+    expect((screen.getByRole('checkbox') as HTMLInputElement).checked).toBe(false);
+  });
+
+  it('renders the checkbox as unchecked when checked is not provided', () => {
+    render(<ShowAllToggle onChange={vi.fn()} />);
+    expect((screen.getByRole('checkbox') as HTMLInputElement).checked).toBe(false);
+  });
+
+  it('renders the checkbox as checked when checked is true', () => {
+    render(<ShowAllToggle checked={true} onChange={vi.fn()} />);
+    expect((screen.getByRole('checkbox') as HTMLInputElement).checked).toBe(true);
+  });
+
+  it('calls onChange with true when the checkbox is clicked while unchecked', async () => {
+    const onChange = vi.fn();
+    render(<ShowAllToggle checked={false} onChange={onChange} />);
+    await userEvent.click(screen.getByRole('checkbox'));
+    expect(onChange).toHaveBeenCalledExactlyOnceWith(true);
+  });
+
+  it('calls onChange with false when the checkbox is clicked while checked', async () => {
+    const onChange = vi.fn();
+    render(<ShowAllToggle checked={true} onChange={onChange} />);
+    await userEvent.click(screen.getByRole('checkbox'));
+    expect(onChange).toHaveBeenCalledExactlyOnceWith(false);
+  });
+});

--- a/app/adventure/events/ui/show-all-toggle.tsx
+++ b/app/adventure/events/ui/show-all-toggle.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+interface ShowAllToggleProperties {
+  checked?: boolean;
+  onChange?: (checked: boolean) => void;
+}
+
+const ShowAllToggle = ({ checked, onChange }: ShowAllToggleProperties) => {
+  return (
+    <label className="flex items-center gap-2 cursor-pointer select-none">
+      <input
+        type="checkbox"
+        className="checkbox checkbox-sm"
+        defaultChecked={checked}
+        onChange={(e) => onChange?.(e.target.checked)}
+      />
+      <span className="text-sm">Show All</span>
+    </label>
+  );
+};
+
+export default ShowAllToggle;

--- a/app/adventure/events/ui/show-all-toggle.tsx
+++ b/app/adventure/events/ui/show-all-toggle.tsx
@@ -11,7 +11,7 @@ const ShowAllToggle = ({ checked, onChange }: ShowAllToggleProperties) => {
       <input
         type="checkbox"
         className="checkbox checkbox-sm"
-        defaultChecked={checked}
+        checked={!!checked}
         onChange={(e) => onChange?.(e.target.checked)}
       />
       <span className="text-sm">Show All</span>


### PR DESCRIPTION
Implement 'Show All' checkboxes for upcoming and prior events, allowing users to view all or bounded event lists, with preferences persisted via cookies. Display a 'no events' message when a section is empty instead of hiding it entirely. Relates to #85