### PR TITLE
Add PlaceCard component

### DIFF
--- a/app/adventure/events/ui/__tests__/event-card.spec.tsx
+++ b/app/adventure/events/ui/__tests__/event-card.spec.tsx
@@ -51,13 +51,13 @@ describe('Event Card', () => {
   describe('delete link', () => {
     it('links to the delete page for the event', () => {
       render(<EventCard event={TEST_EVENT} callingPage="/adventure" />);
-      const link = screen.getByRole('button', { name: /delete/i }).closest('a');
+      const link = screen.getByRole('link', { name: /delete/i }).closest('a');
       expect(link?.getAttribute('href')).toBe(`/adventure/events/${TEST_EVENT.id}/delete?callingPage=/adventure`);
     });
 
     it('does not include the search parameter when callingPage is not provided', () => {
       render(<EventCard event={TEST_EVENT} />);
-      const link = screen.getByRole('button', { name: /delete/i }).closest('a');
+      const link = screen.getByRole('link', { name: /delete/i }).closest('a');
       expect(link?.getAttribute('href')).toBe(`/adventure/events/${TEST_EVENT.id}/delete`);
     });
   });
@@ -65,13 +65,13 @@ describe('Event Card', () => {
   describe('edit link', () => {
     it('links to the update page for the event', () => {
       render(<EventCard event={TEST_EVENT} callingPage="/adventure" />);
-      const link = screen.getByRole('button', { name: /edit/i }).closest('a');
+      const link = screen.getByRole('link', { name: /edit/i }).closest('a');
       expect(link?.getAttribute('href')).toBe(`/adventure/events/${TEST_EVENT.id}/update?callingPage=/adventure`);
     });
 
     it('does not include the search parameter when callingPage is not provided', () => {
       render(<EventCard event={TEST_EVENT} />);
-      const link = screen.getByRole('button', { name: /edit/i }).closest('a');
+      const link = screen.getByRole('link', { name: /edit/i }).closest('a');
       expect(link?.getAttribute('href')).toBe(`/adventure/events/${TEST_EVENT.id}/update`);
     });
   });

--- a/app/adventure/events/ui/event-card.tsx
+++ b/app/adventure/events/ui/event-card.tsx
@@ -24,15 +24,19 @@ const EventCard = ({ event, callingPage }: EventCardProps) => {
         <p>{event.place.name}</p>
 
         <div className="card-actions justify-end items-center mt-6">
-          <Link href={`/adventure/events/${event.id}/delete${searchParams}`}>
-            <button className="btn btn-error btn-outline btn-circle" aria-label="Delete the event">
-              <TrashIcon className="w-6" />
-            </button>
+          <Link
+            href={`/adventure/events/${event.id}/delete${searchParams}`}
+            className="btn btn-error btn-outline btn-circle"
+            aria-label="Delete the event"
+          >
+            <TrashIcon className="w-6" />
           </Link>
-          <Link href={`/adventure/events/${event.id}/update${searchParams}`}>
-            <button className="btn btn-secondary btn-outline btn-circle" aria-label="Edit the event">
-              <PencilSquareIcon className="w-6" />
-            </button>
+          <Link
+            href={`/adventure/events/${event.id}/update${searchParams}`}
+            className="btn btn-secondary btn-outline btn-circle"
+            aria-label="Edit the event"
+          >
+            <PencilSquareIcon className="w-6" />
           </Link>
         </div>
       </div>

--- a/app/adventure/places/places.tsx
+++ b/app/adventure/places/places.tsx
@@ -1,16 +1,12 @@
 import { Place } from '@/models';
-import PlaceCard from './ui/place-card';
+import PlacesList from './places-list';
+import PlacesTable from './places-table';
 
 const Places = ({ places }: { places: Array<Place> }) => {
   return (
     <>
-      <div className="grid gap-2 grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 ">
-        {places.map((x) => (
-          <PlaceCard place={x} key={x.id} />
-        ))}
-      </div>
-      {/* <PlacesTable className="hidden md:table" places={places} />
-      <PlacesList className="block md:hidden" places={places} /> */}
+      <PlacesTable className="hidden md:table" places={places} />
+      <PlacesList className="block md:hidden" places={places} />
     </>
   );
 };

--- a/app/adventure/places/places.tsx
+++ b/app/adventure/places/places.tsx
@@ -1,12 +1,16 @@
 import { Place } from '@/models';
-import PlacesList from './places-list';
-import PlacesTable from './places-table';
+import PlaceCard from './ui/place-card';
 
 const Places = ({ places }: { places: Array<Place> }) => {
   return (
     <>
-      <PlacesTable className="hidden md:table" places={places} />
-      <PlacesList className="block md:hidden" places={places} />
+      <div className="grid gap-2 grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 ">
+        {places.map((x) => (
+          <PlaceCard place={x} key={x.id} />
+        ))}
+      </div>
+      {/* <PlacesTable className="hidden md:table" places={places} />
+      <PlacesList className="block md:hidden" places={places} /> */}
     </>
   );
 };

--- a/app/adventure/places/ui/__tests__/place-card.spec.tsx
+++ b/app/adventure/places/ui/__tests__/place-card.spec.tsx
@@ -1,0 +1,122 @@
+import { Place } from '@/models';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PLACE_TYPES } from '../../__mocks__/data';
+import PlaceCard from '../place-card';
+
+describe('Place Card', () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => cleanup());
+
+  it('renders the place name', () => {
+    render(<PlaceCard place={TEST_PLACE} />);
+    expect(screen.getByRole('heading', { level: 3, name: TEST_PLACE.name })).toBeDefined();
+  });
+
+  it('renders the place type', () => {
+    render(<PlaceCard place={TEST_PLACE} />);
+    expect(screen.getByText(TEST_PLACE.type.name)).toBeDefined();
+  });
+
+  describe('name link', () => {
+    it('links to the place detail page', () => {
+      render(<PlaceCard place={TEST_PLACE} callingPage="/adventure/places" />);
+      const link = screen.getByRole('link', { name: TEST_PLACE.name });
+      expect(link.getAttribute('href')).toBe(`/adventure/places/${TEST_PLACE.id}?callingPage=/adventure/places`);
+    });
+
+    it('does not include the search parameter when callingPage is not provided', () => {
+      render(<PlaceCard place={TEST_PLACE} />);
+      const link = screen.getByRole('link', { name: TEST_PLACE.name });
+      expect(link.getAttribute('href')).toBe(`/adventure/places/${TEST_PLACE.id}`);
+    });
+  });
+
+  describe.skip('address', () => {
+    it('renders the address when present', () => {
+      render(<PlaceCard place={TEST_PLACE} />);
+      expect(screen.getByText(TEST_PLACE.address.line1!)).toBeDefined();
+    });
+
+    it('does not render the address when not present', () => {
+      render(<PlaceCard place={TEST_PLACE_NO_ADDRESS} />);
+      expect(screen.queryByText(TEST_PLACE.address.line1!)).toBeNull();
+    });
+  });
+
+  describe.skip('phone number', () => {
+    it('renders the phone number when present', () => {
+      render(<PlaceCard place={TEST_PLACE} />);
+      expect(screen.getByText(TEST_PLACE.phoneNumber!)).toBeDefined();
+    });
+
+    it('does not render the phone number when not present', () => {
+      render(<PlaceCard place={TEST_PLACE_NO_PHONE} />);
+      expect(screen.queryByText(TEST_PLACE.phoneNumber!)).toBeNull();
+    });
+  });
+
+  describe('delete link', () => {
+    it('links to the delete page for the place', () => {
+      render(<PlaceCard place={TEST_PLACE} callingPage="/adventure/places" />);
+      const link = screen.getByRole('button', { name: /delete/i }).closest('a');
+      expect(link?.getAttribute('href')).toBe(
+        `/adventure/places/${TEST_PLACE.id}/delete?callingPage=/adventure/places`,
+      );
+    });
+
+    it('does not include the search parameter when callingPage is not provided', () => {
+      render(<PlaceCard place={TEST_PLACE} />);
+      const link = screen.getByRole('button', { name: /delete/i }).closest('a');
+      expect(link?.getAttribute('href')).toBe(`/adventure/places/${TEST_PLACE.id}/delete`);
+    });
+  });
+
+  describe('edit link', () => {
+    it('links to the update page for the place', () => {
+      render(<PlaceCard place={TEST_PLACE} callingPage="/adventure/places" />);
+      const link = screen.getByRole('button', { name: /edit/i }).closest('a');
+      expect(link?.getAttribute('href')).toBe(
+        `/adventure/places/${TEST_PLACE.id}/update?callingPage=/adventure/places`,
+      );
+    });
+
+    it('does not include the search parameter when callingPage is not provided', () => {
+      render(<PlaceCard place={TEST_PLACE} />);
+      const link = screen.getByRole('button', { name: /edit/i }).closest('a');
+      expect(link?.getAttribute('href')).toBe(`/adventure/places/${TEST_PLACE.id}/update`);
+    });
+  });
+});
+
+const TEST_PLACE: Place = {
+  id: 42,
+  name: 'Burnet State Park',
+  description: null,
+  address: {
+    line1: '23125 255th St.',
+    line2: null,
+    city: 'Cornell',
+    state: 'WI',
+    postal: '54732',
+  },
+  type: PLACE_TYPES[0],
+  phoneNumber: '(715) 239-6888',
+  website: null,
+};
+
+const TEST_PLACE_NO_ADDRESS: Place = {
+  ...TEST_PLACE,
+  address: {
+    line1: null,
+    line2: null,
+    city: null,
+    state: null,
+    postal: null,
+  },
+};
+
+const TEST_PLACE_NO_PHONE: Place = {
+  ...TEST_PLACE,
+  phoneNumber: null,
+};

--- a/app/adventure/places/ui/__tests__/place-card.spec.tsx
+++ b/app/adventure/places/ui/__tests__/place-card.spec.tsx
@@ -70,7 +70,7 @@ describe('Place Card', () => {
   describe('delete link', () => {
     it('links to the delete page for the place', () => {
       render(<PlaceCard place={TEST_PLACE} callingPage="/adventure/places" />);
-      const link = screen.getByRole('button', { name: /delete/i }).closest('a');
+      const link = screen.getByRole('link', { name: /delete/i }).closest('a');
       expect(link?.getAttribute('href')).toBe(
         `/adventure/places/${TEST_PLACE.id}/delete?callingPage=/adventure/places`,
       );
@@ -78,7 +78,7 @@ describe('Place Card', () => {
 
     it('does not include the search parameter when callingPage is not provided', () => {
       render(<PlaceCard place={TEST_PLACE} />);
-      const link = screen.getByRole('button', { name: /delete/i }).closest('a');
+      const link = screen.getByRole('link', { name: /delete/i }).closest('a');
       expect(link?.getAttribute('href')).toBe(`/adventure/places/${TEST_PLACE.id}/delete`);
     });
   });
@@ -86,7 +86,7 @@ describe('Place Card', () => {
   describe('edit link', () => {
     it('links to the update page for the place', () => {
       render(<PlaceCard place={TEST_PLACE} callingPage="/adventure/places" />);
-      const link = screen.getByRole('button', { name: /edit/i }).closest('a');
+      const link = screen.getByRole('link', { name: /edit/i }).closest('a');
       expect(link?.getAttribute('href')).toBe(
         `/adventure/places/${TEST_PLACE.id}/update?callingPage=/adventure/places`,
       );
@@ -94,7 +94,7 @@ describe('Place Card', () => {
 
     it('does not include the search parameter when callingPage is not provided', () => {
       render(<PlaceCard place={TEST_PLACE} />);
-      const link = screen.getByRole('button', { name: /edit/i }).closest('a');
+      const link = screen.getByRole('link', { name: /edit/i }).closest('a');
       expect(link?.getAttribute('href')).toBe(`/adventure/places/${TEST_PLACE.id}/update`);
     });
   });

--- a/app/adventure/places/ui/__tests__/place-card.spec.tsx
+++ b/app/adventure/places/ui/__tests__/place-card.spec.tsx
@@ -11,7 +11,7 @@ describe('Place Card', () => {
   describe('main title', () => {
     it('renders the place name', () => {
       render(<PlaceCard place={TEST_PLACE} />);
-      expect(screen.getByRole('heading', { level: 3, name: TEST_PLACE.name })).toBeDefined();
+      expect(screen.getByRole('heading', { level: 3, name: new RegExp(TEST_PLACE.name) })).toBeDefined();
     });
 
     it('links to the place detail page', () => {
@@ -25,6 +25,14 @@ describe('Place Card', () => {
       render(<PlaceCard place={TEST_PLACE} />);
       const link = screen.getByRole('link', { name: TEST_PLACE.name });
       expect(link.getAttribute('href')).toBe(`/adventure/places/${TEST_PLACE.id}`);
+    });
+  });
+
+  describe('place type icon', () => {
+    it('renders the icon corresponding to the place type', () => {
+      render(<PlaceCard place={TEST_PLACE} />);
+      const heading = screen.getByRole('heading', { level: 3 });
+      expect(within(heading).getByRole('img', { name: `${TEST_PLACE.type.name} icon` })).toBeDefined();
     });
   });
 

--- a/app/adventure/places/ui/__tests__/place-card.spec.tsx
+++ b/app/adventure/places/ui/__tests__/place-card.spec.tsx
@@ -1,5 +1,5 @@
 import { Place } from '@/models';
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, render, screen, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PLACE_TYPES } from '../../__mocks__/data';
 import PlaceCard from '../place-card';
@@ -8,20 +8,16 @@ describe('Place Card', () => {
   beforeEach(() => vi.clearAllMocks());
   afterEach(() => cleanup());
 
-  it('renders the place name', () => {
-    render(<PlaceCard place={TEST_PLACE} />);
-    expect(screen.getByRole('heading', { level: 3, name: TEST_PLACE.name })).toBeDefined();
-  });
+  describe('main title', () => {
+    it('renders the place name', () => {
+      render(<PlaceCard place={TEST_PLACE} />);
+      expect(screen.getByRole('heading', { level: 3, name: TEST_PLACE.name })).toBeDefined();
+    });
 
-  it('renders the place type', () => {
-    render(<PlaceCard place={TEST_PLACE} />);
-    expect(screen.getByText(TEST_PLACE.type.name)).toBeDefined();
-  });
-
-  describe('name link', () => {
     it('links to the place detail page', () => {
       render(<PlaceCard place={TEST_PLACE} callingPage="/adventure/places" />);
-      const link = screen.getByRole('link', { name: TEST_PLACE.name });
+      const headerLink = screen.getByRole('heading', { level: 3 });
+      const link = within(headerLink).getByRole('link', { name: TEST_PLACE.name });
       expect(link.getAttribute('href')).toBe(`/adventure/places/${TEST_PLACE.id}?callingPage=/adventure/places`);
     });
 
@@ -32,7 +28,14 @@ describe('Place Card', () => {
     });
   });
 
-  describe.skip('address', () => {
+  describe('sub title', () => {
+    it('renders the place type', () => {
+      render(<PlaceCard place={TEST_PLACE} />);
+      expect(screen.getByRole('heading', { level: 4, name: TEST_PLACE.type.name })).toBeDefined();
+    });
+  });
+
+  describe('address', () => {
     it('renders the address when present', () => {
       render(<PlaceCard place={TEST_PLACE} />);
       expect(screen.getByText(TEST_PLACE.address.line1!)).toBeDefined();
@@ -44,7 +47,7 @@ describe('Place Card', () => {
     });
   });
 
-  describe.skip('phone number', () => {
+  describe('phone number', () => {
     it('renders the phone number when present', () => {
       render(<PlaceCard place={TEST_PLACE} />);
       expect(screen.getByText(TEST_PLACE.phoneNumber!)).toBeDefined();

--- a/app/adventure/places/ui/__tests__/place-type-icon.spec.tsx
+++ b/app/adventure/places/ui/__tests__/place-type-icon.spec.tsx
@@ -1,0 +1,45 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import PlaceTypeIcon from '../place-type-icon';
+
+describe('PlaceTypeIcon', () => {
+  afterEach(() => cleanup());
+
+  describe('known place types', () => {
+    it.each([
+      'Attraction',
+      'Campground',
+      'Lodging',
+      'Motorplex',
+      'Museum',
+      'Restaurant',
+      'Sports Arena',
+      'State Park',
+      'Theater',
+    ])('renders an icon for %s', (typeName) => {
+      render(<PlaceTypeIcon typeName={typeName} />);
+      expect(screen.getByRole('img', { name: `${typeName} icon` })).toBeDefined();
+    });
+  });
+
+  describe('unknown place type', () => {
+    it('renders a fallback icon for an unrecognised place type', () => {
+      render(<PlaceTypeIcon typeName="Unknown Type" />);
+      expect(screen.getByRole('img', { name: 'Unknown Type icon' })).toBeDefined();
+    });
+  });
+
+  describe('className', () => {
+    it('applies a default class to the icon', () => {
+      render(<PlaceTypeIcon typeName="State Park" />);
+      const icon = screen.getByRole('img', { name: 'State Park icon' });
+      expect(icon.querySelector('svg')?.classList.contains('w-6')).toBe(true);
+    });
+
+    it('applies a custom class when provided', () => {
+      render(<PlaceTypeIcon typeName="State Park" className="w-8 h-8" />);
+      const icon = screen.getByRole('img', { name: 'State Park icon' });
+      expect(icon.querySelector('svg')?.classList.contains('w-8')).toBe(true);
+    });
+  });
+});

--- a/app/adventure/places/ui/place-card.tsx
+++ b/app/adventure/places/ui/place-card.tsx
@@ -25,15 +25,19 @@ const PlaceCard = ({ place, callingPage }: PlaceCardProps) => {
         {place.phoneNumber && <div>{place.phoneNumber}</div>}
 
         <div className="card-actions justify-end items-center mt-6">
-          <Link href={`/adventure/places/${place.id}/delete${searchParams}`}>
-            <button className="btn btn-error btn-outline btn-circle" aria-label="Delete the place">
-              <TrashIcon className="w-6" />
-            </button>
+          <Link
+            href={`/adventure/places/${place.id}/delete${searchParams}`}
+            className="btn btn-error btn-outline btn-circle"
+            aria-label="Delete the place"
+          >
+            <TrashIcon className="w-6" />
           </Link>
-          <Link href={`/adventure/places/${place.id}/update${searchParams}`}>
-            <button className="btn btn-secondary btn-outline btn-circle" aria-label="Edit the place">
-              <PencilSquareIcon className="w-6" />
-            </button>
+          <Link
+            href={`/adventure/places/${place.id}/update${searchParams}`}
+            className="btn btn-secondary btn-outline btn-circle"
+            aria-label="Edit the place"
+          >
+            <PencilSquareIcon className="w-6" />
           </Link>
         </div>
       </div>

--- a/app/adventure/places/ui/place-card.tsx
+++ b/app/adventure/places/ui/place-card.tsx
@@ -1,0 +1,39 @@
+import { Place } from '@/models';
+import { PencilSquareIcon, TrashIcon } from '@heroicons/react/24/outline';
+import Link from 'next/link';
+
+export interface PlaceCardProps {
+  place: Place;
+  callingPage?: string;
+}
+
+const PlaceCard = ({ place, callingPage }: PlaceCardProps) => {
+  const searchParams = callingPage ? `?callingPage=${callingPage}` : '';
+
+  return (
+    <div className="card card-border bg-base-100">
+      <div className="card-body">
+        <h3 className="card-title">{place.name}</h3>
+        <h4 className="card-sub-title">
+          <Link href={`/adventure/places/${place.id}${searchParams}`}>{place.name}</Link>
+        </h4>
+        <p>{place.type.name}</p>
+
+        <div className="card-actions justify-end items-center mt-6">
+          <Link href={`/adventure/places/${place.id}/delete${searchParams}`}>
+            <button className="btn btn-error btn-outline btn-circle" aria-label="Delete the place">
+              <TrashIcon className="w-6" />
+            </button>
+          </Link>
+          <Link href={`/adventure/places/${place.id}/update${searchParams}`}>
+            <button className="btn btn-secondary btn-outline btn-circle" aria-label="Edit the place">
+              <PencilSquareIcon className="w-6" />
+            </button>
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PlaceCard;

--- a/app/adventure/places/ui/place-card.tsx
+++ b/app/adventure/places/ui/place-card.tsx
@@ -3,6 +3,7 @@ import LabeledField from '@/app/ui/labeled-field';
 import { Place } from '@/models';
 import { PencilSquareIcon, TrashIcon } from '@heroicons/react/24/outline';
 import Link from 'next/link';
+import PlaceTypeIcon from './place-type-icon';
 
 export interface PlaceCardProps {
   place: Place;
@@ -15,8 +16,9 @@ const PlaceCard = ({ place, callingPage }: PlaceCardProps) => {
   return (
     <div className="card card-border bg-base-100">
       <div className="card-body">
-        <h3 className="card-title">
+        <h3 className="card-title justify-between">
           <Link href={`/adventure/places/${place.id}${searchParams}`}>{place.name}</Link>
+          <PlaceTypeIcon typeName={place.type.name} />
         </h3>
         <h4 className="card-sub-title">{place.type.name}</h4>
 

--- a/app/adventure/places/ui/place-card.tsx
+++ b/app/adventure/places/ui/place-card.tsx
@@ -1,5 +1,4 @@
 import Address from '@/app/ui/address';
-import LabeledField from '@/app/ui/labeled-field';
 import { Place } from '@/models';
 import { PencilSquareIcon, TrashIcon } from '@heroicons/react/24/outline';
 import Link from 'next/link';

--- a/app/adventure/places/ui/place-card.tsx
+++ b/app/adventure/places/ui/place-card.tsx
@@ -1,3 +1,5 @@
+import Address from '@/app/ui/address';
+import LabeledField from '@/app/ui/labeled-field';
 import { Place } from '@/models';
 import { PencilSquareIcon, TrashIcon } from '@heroicons/react/24/outline';
 import Link from 'next/link';
@@ -13,11 +15,13 @@ const PlaceCard = ({ place, callingPage }: PlaceCardProps) => {
   return (
     <div className="card card-border bg-base-100">
       <div className="card-body">
-        <h3 className="card-title">{place.name}</h3>
-        <h4 className="card-sub-title">
+        <h3 className="card-title">
           <Link href={`/adventure/places/${place.id}${searchParams}`}>{place.name}</Link>
-        </h4>
-        <p>{place.type.name}</p>
+        </h3>
+        <h4 className="card-sub-title">{place.type.name}</h4>
+
+        <Address value={place.address} />
+        {place.phoneNumber && <div>{place.phoneNumber}</div>}
 
         <div className="card-actions justify-end items-center mt-6">
           <Link href={`/adventure/places/${place.id}/delete${searchParams}`}>

--- a/app/adventure/places/ui/place-type-icon.tsx
+++ b/app/adventure/places/ui/place-type-icon.tsx
@@ -1,0 +1,41 @@
+import {
+  BuildingLibraryIcon,
+  CakeIcon,
+  FilmIcon,
+  FireIcon,
+  HomeModernIcon,
+  QuestionMarkCircleIcon,
+  SparklesIcon,
+  SunIcon,
+  TicketIcon,
+  TrophyIcon,
+} from '@heroicons/react/24/outline';
+import { ComponentType, SVGProps } from 'react';
+
+export interface PlaceTypeIconProps {
+  typeName: string;
+  className?: string;
+}
+
+const PLACE_TYPE_ICONS: Record<string, ComponentType<SVGProps<SVGSVGElement>>> = {
+  Attraction: SparklesIcon,
+  Campground: FireIcon,
+  Lodging: HomeModernIcon,
+  Motorplex: TrophyIcon,
+  Museum: BuildingLibraryIcon,
+  Restaurant: CakeIcon,
+  'Sports Arena': TicketIcon,
+  'State Park': SunIcon,
+  Theater: FilmIcon,
+};
+
+const PlaceTypeIcon = ({ typeName, className = 'w-6' }: PlaceTypeIconProps) => {
+  const Icon = PLACE_TYPE_ICONS[typeName] ?? QuestionMarkCircleIcon;
+  return (
+    <span role="img" aria-label={`${typeName} icon`}>
+      <Icon className={className} />
+    </span>
+  );
+};
+
+export default PlaceTypeIcon;


### PR DESCRIPTION
Introduce the `PlaceCard` component to display place information and navigation links, supported by `PlaceTypeIcon` for visual cues. Include comprehensive unit tests for both components. Relates to #97