### PR TITLE
Add search filter to places display

### DIFF
--- a/app/adventure/places/__tests__/filtered-places.spec.tsx
+++ b/app/adventure/places/__tests__/filtered-places.spec.tsx
@@ -85,6 +85,52 @@ describe('Filtered Places', () => {
     });
   });
 
+  describe('Search input', () => {
+    it('renders a search input', () => {
+      render(<FilteredPlaces places={places} placeTypes={placeTypes} />);
+      expect(screen.getByRole('searchbox', { name: 'Search' })).toBeDefined();
+    });
+
+    it('defaults to empty', () => {
+      render(<FilteredPlaces places={places} placeTypes={placeTypes} />);
+      const input = screen.getByRole('searchbox', { name: 'Search' }) as HTMLInputElement;
+      expect(input.value).toBe('');
+    });
+
+    it('filters places by name as the user types', async () => {
+      const user = userEvent.setup();
+      render(<FilteredPlaces places={places} placeTypes={placeTypes} />);
+      const input = screen.getByRole('searchbox', { name: 'Search' });
+
+      await user.type(input, 'bong');
+
+      expect(screen.getByRole('link', { name: 'Richard Bong State Park' })).toBeDefined();
+      expect(screen.queryByRole('link', { name: 'Burnet State Park' })).toBeNull();
+    });
+
+    it('is case-insensitive', async () => {
+      const user = userEvent.setup();
+      render(<FilteredPlaces places={places} placeTypes={placeTypes} />);
+      const input = screen.getByRole('searchbox', { name: 'Search' });
+
+      await user.type(input, 'BONG');
+
+      expect(screen.getByRole('link', { name: 'Richard Bong State Park' })).toBeDefined();
+    });
+
+    it('combines with the Place Type filter', async () => {
+      const user = userEvent.setup();
+      render(<FilteredPlaces places={places} placeTypes={placeTypes} />);
+
+      await user.selectOptions(screen.getByRole('combobox', { name: 'Place Type' }), String(PLACE_TYPES[0].id));
+      await user.type(screen.getByRole('searchbox', { name: 'Search' }), 'bong');
+
+      expect(screen.getByRole('link', { name: 'Richard Bong State Park' })).toBeDefined();
+      expect(screen.queryByRole('link', { name: 'Burnet State Park' })).toBeNull();
+      expect(screen.queryByRole('link', { name: 'Indianapolis Motor Speedway' })).toBeNull();
+    });
+  });
+
   describe('Clear Filter', () => {
     it('renders', () => {
       render(<FilteredPlaces places={places} placeTypes={placeTypes} />);
@@ -104,6 +150,18 @@ describe('Filtered Places', () => {
       places.forEach((p) => {
         expect(screen.getByRole('link', { name: p.name })).toBeDefined();
       });
+    });
+
+    it('resets the search input', async () => {
+      const user = userEvent.setup();
+      render(<FilteredPlaces places={places} placeTypes={placeTypes} />);
+      const input = screen.getByRole('searchbox', { name: 'Search' }) as HTMLInputElement;
+
+      await user.type(input, 'bong');
+
+      await user.click(screen.getByRole('button', { name: /clear filter/i }));
+
+      expect(input.value).toBe('');
     });
 
     it('resets the Place Type dropdown to "All"', async () => {

--- a/app/adventure/places/__tests__/filtered-places.spec.tsx
+++ b/app/adventure/places/__tests__/filtered-places.spec.tsx
@@ -118,6 +118,39 @@ describe('Filtered Places', () => {
       expect(screen.getByRole('link', { name: 'Richard Bong State Park' })).toBeDefined();
     });
 
+    it('filters places by city', async () => {
+      const user = userEvent.setup();
+      render(<FilteredPlaces places={places} placeTypes={placeTypes} />);
+
+      await user.type(screen.getByRole('searchbox', { name: 'Search' }), 'cornell');
+
+      expect(screen.getByRole('link', { name: 'Burnet State Park' })).toBeDefined();
+      expect(screen.queryByRole('link', { name: 'Indianapolis Motor Speedway' })).toBeNull();
+    });
+
+    it('filters places by state', async () => {
+      const user = userEvent.setup();
+      render(<FilteredPlaces places={places} placeTypes={placeTypes} />);
+
+      await user.type(screen.getByRole('searchbox', { name: 'Search' }), 'WI');
+
+      const wiPlaces = PLACES.filter((p) => p.address.state === 'WI');
+      const nonWiPlaces = PLACES.filter((p) => p.address.state !== 'WI');
+
+      wiPlaces.forEach((p) => expect(screen.getByRole('link', { name: p.name })).toBeDefined());
+      nonWiPlaces.forEach((p) => expect(screen.queryByRole('link', { name: p.name })).toBeNull());
+    });
+
+    it('filters places by street address', async () => {
+      const user = userEvent.setup();
+      render(<FilteredPlaces places={places} placeTypes={placeTypes} />);
+
+      await user.type(screen.getByRole('searchbox', { name: 'Search' }), '255th');
+
+      expect(screen.getByRole('link', { name: 'Burnet State Park' })).toBeDefined();
+      expect(screen.queryByRole('link', { name: 'Indianapolis Motor Speedway' })).toBeNull();
+    });
+
     it('combines with the Place Type filter', async () => {
       const user = userEvent.setup();
       render(<FilteredPlaces places={places} placeTypes={placeTypes} />);

--- a/app/adventure/places/filtered-places.tsx
+++ b/app/adventure/places/filtered-places.tsx
@@ -11,11 +11,18 @@ export interface FilteredPlacesProps {
 
 const FilteredPlaces = ({ places, placeTypes }: FilteredPlacesProps) => {
   const [selectedTypeId, setSelectedTypeId] = useState<number | null>(null);
+  const [searchText, setSearchText] = useState('');
 
-  const filteredPlaces =
-    selectedTypeId !== null ? places.filter((p) => p.type.id === selectedTypeId) : places;
+  const filteredPlaces = places.filter((p) => {
+    const matchesType = selectedTypeId === null || p.type.id === selectedTypeId;
+    const matchesSearch = p.name.toLowerCase().includes(searchText.toLowerCase().trim());
+    return matchesType && matchesSearch;
+  });
 
-  const clearFilters = () => setSelectedTypeId(null);
+  const clearFilters = () => {
+    setSelectedTypeId(null);
+    setSearchText('');
+  };
 
   return (
     <>
@@ -36,6 +43,14 @@ const FilteredPlaces = ({ places, placeTypes }: FilteredPlacesProps) => {
             ))}
           </select>
         </label>
+        <input
+          type="search"
+          className="input input-bordered mx-4"
+          aria-label="Search"
+          placeholder="Search"
+          value={searchText}
+          onChange={(e) => setSearchText(e.target.value)}
+        />
         <div className="grow" />
         <button className="btn btn-ghost" onClick={clearFilters}>
           Clear Filter

--- a/app/adventure/places/filtered-places.tsx
+++ b/app/adventure/places/filtered-places.tsx
@@ -51,7 +51,7 @@ const FilteredPlaces = ({ places, placeTypes }: FilteredPlacesProps) => {
           value={searchText}
           onChange={(e) => setSearchText(e.target.value)}
         />
-        <div className="flex justify-end">
+        <div className="flex justify-center md:justify-end">
           <button className="btn btn-ghost" onClick={clearFilters}>
             Clear Filter
           </button>

--- a/app/adventure/places/filtered-places.tsx
+++ b/app/adventure/places/filtered-places.tsx
@@ -15,7 +15,12 @@ const FilteredPlaces = ({ places, placeTypes }: FilteredPlacesProps) => {
 
   const filteredPlaces = places.filter((p) => {
     const matchesType = selectedTypeId === null || p.type.id === selectedTypeId;
-    const matchesSearch = p.name.toLowerCase().includes(searchText.toLowerCase().trim());
+    const needle = searchText.toLowerCase().trim();
+    const matchesSearch =
+      !needle ||
+      [p.name, p.address.line1, p.address.line2, p.address.city, p.address.state, p.address.postal].some((field) =>
+        field?.toLowerCase().includes(needle),
+      );
     return matchesType && matchesSearch;
   });
 

--- a/app/adventure/places/filtered-places.tsx
+++ b/app/adventure/places/filtered-places.tsx
@@ -26,11 +26,11 @@ const FilteredPlaces = ({ places, placeTypes }: FilteredPlacesProps) => {
 
   return (
     <>
-      <div className="grid grid-cols-1 md:flex md:items-center gap-2 mb-4">
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-2 items-center mb-4">
         <label className="flex items-center gap-2">
           <span>Place Type</span>
           <select
-            className="select select-bordered"
+            className="select select-bordered flex-1"
             aria-label="Place Type"
             value={selectedTypeId ?? ''}
             onChange={(e) => setSelectedTypeId(e.target.value ? +e.target.value : null)}
@@ -45,15 +45,17 @@ const FilteredPlaces = ({ places, placeTypes }: FilteredPlacesProps) => {
         </label>
         <input
           type="search"
-          className="input input-bordered md:flex-1"
+          className="input input-bordered md:col-span-2"
           aria-label="Search"
           placeholder="Search"
           value={searchText}
           onChange={(e) => setSearchText(e.target.value)}
         />
-        <button className="btn btn-ghost md:ml-auto" onClick={clearFilters}>
-          Clear Filter
-        </button>
+        <div className="flex justify-end">
+          <button className="btn btn-ghost" onClick={clearFilters}>
+            Clear Filter
+          </button>
+        </div>
       </div>
       <div className="grid gap-2 grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3">
         {filteredPlaces.map((x) => (

--- a/app/adventure/places/filtered-places.tsx
+++ b/app/adventure/places/filtered-places.tsx
@@ -26,7 +26,7 @@ const FilteredPlaces = ({ places, placeTypes }: FilteredPlacesProps) => {
 
   return (
     <>
-      <div className="flex w-full items-center mb-4">
+      <div className="grid grid-cols-1 md:flex md:items-center gap-2 mb-4">
         <label className="flex items-center gap-2">
           <span>Place Type</span>
           <select
@@ -45,14 +45,13 @@ const FilteredPlaces = ({ places, placeTypes }: FilteredPlacesProps) => {
         </label>
         <input
           type="search"
-          className="input input-bordered mx-4"
+          className="input input-bordered md:flex-1"
           aria-label="Search"
           placeholder="Search"
           value={searchText}
           onChange={(e) => setSearchText(e.target.value)}
         />
-        <div className="grow" />
-        <button className="btn btn-ghost" onClick={clearFilters}>
+        <button className="btn btn-ghost md:ml-auto" onClick={clearFilters}>
           Clear Filter
         </button>
       </div>

--- a/app/adventure/places/filtered-places.tsx
+++ b/app/adventure/places/filtered-places.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Place, PlaceType } from '@/models';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import PlaceCard from './ui/place-card';
 
 export interface FilteredPlacesProps {
@@ -12,17 +12,24 @@ export interface FilteredPlacesProps {
 const FilteredPlaces = ({ places, placeTypes }: FilteredPlacesProps) => {
   const [selectedTypeId, setSelectedTypeId] = useState<number | null>(null);
   const [searchText, setSearchText] = useState('');
+  const needle = searchText.toLowerCase().trim();
 
-  const filteredPlaces = places.filter((p) => {
-    const matchesType = selectedTypeId === null || p.type.id === selectedTypeId;
-    const needle = searchText.toLowerCase().trim();
-    const matchesSearch =
-      !needle ||
-      [p.name, p.address.line1, p.address.line2, p.address.city, p.address.state, p.address.postal].some((field) =>
-        field?.toLowerCase().includes(needle),
-      );
-    return matchesType && matchesSearch;
-  });
+  const filteredPlaces = useMemo(
+    () =>
+      places.filter((p) => {
+        const matchesType = selectedTypeId === null || p.type.id === selectedTypeId;
+        const matchesSearch =
+          !needle ||
+          p.name.toLowerCase().includes(needle) ||
+          p.address.line1?.toLowerCase().includes(needle) ||
+          p.address.line2?.toLowerCase().includes(needle) ||
+          p.address.city?.toLowerCase().includes(needle) ||
+          p.address.state?.toLowerCase().includes(needle) ||
+          p.address.postal?.toLowerCase().includes(needle);
+        return matchesType && matchesSearch;
+      }),
+    [needle, places, selectedTypeId],
+  );
 
   const clearFilters = () => {
     setSelectedTypeId(null);

--- a/app/adventure/places/filtered-places.tsx
+++ b/app/adventure/places/filtered-places.tsx
@@ -45,7 +45,7 @@ const FilteredPlaces = ({ places, placeTypes }: FilteredPlacesProps) => {
         </label>
         <input
           type="search"
-          className="input input-bordered md:col-span-2"
+          className="input input-bordered w-full md:col-span-2"
           aria-label="Search"
           placeholder="Search"
           value={searchText}

--- a/app/adventure/places/filtered-places.tsx
+++ b/app/adventure/places/filtered-places.tsx
@@ -21,11 +21,11 @@ const FilteredPlaces = ({ places, placeTypes }: FilteredPlacesProps) => {
       const matchesSearch =
         !needle ||
         p.name.toLowerCase().includes(needle) ||
-        p.address.line1?.toLowerCase().includes(needle) ||
-        p.address.line2?.toLowerCase().includes(needle) ||
-        p.address.city?.toLowerCase().includes(needle) ||
-        p.address.state?.toLowerCase().includes(needle) ||
-        p.address.postal?.toLowerCase().includes(needle);
+        p.address.line1?.toLowerCase()?.includes(needle) ||
+        p.address.line2?.toLowerCase()?.includes(needle) ||
+        p.address.city?.toLowerCase()?.includes(needle) ||
+        p.address.state?.toLowerCase()?.includes(needle) ||
+        p.address.postal?.toLowerCase()?.includes(needle);
       return matchesType && matchesSearch;
     });
   }, [places, searchText, selectedTypeId]);

--- a/app/adventure/places/filtered-places.tsx
+++ b/app/adventure/places/filtered-places.tsx
@@ -21,11 +21,11 @@ const FilteredPlaces = ({ places, placeTypes }: FilteredPlacesProps) => {
       const matchesSearch =
         !needle ||
         p.name.toLowerCase().includes(needle) ||
-        p.address.line1?.toLowerCase()?.includes(needle) ||
-        p.address.line2?.toLowerCase()?.includes(needle) ||
-        p.address.city?.toLowerCase()?.includes(needle) ||
-        p.address.state?.toLowerCase()?.includes(needle) ||
-        p.address.postal?.toLowerCase()?.includes(needle);
+        p.address.line1?.toLowerCase().includes(needle) ||
+        p.address.line2?.toLowerCase().includes(needle) ||
+        p.address.city?.toLowerCase().includes(needle) ||
+        p.address.state?.toLowerCase().includes(needle) ||
+        p.address.postal?.toLowerCase().includes(needle);
       return matchesType && matchesSearch;
     });
   }, [places, searchText, selectedTypeId]);

--- a/app/adventure/places/filtered-places.tsx
+++ b/app/adventure/places/filtered-places.tsx
@@ -12,24 +12,23 @@ export interface FilteredPlacesProps {
 const FilteredPlaces = ({ places, placeTypes }: FilteredPlacesProps) => {
   const [selectedTypeId, setSelectedTypeId] = useState<number | null>(null);
   const [searchText, setSearchText] = useState('');
-  const needle = searchText.toLowerCase().trim();
 
-  const filteredPlaces = useMemo(
-    () =>
-      places.filter((p) => {
-        const matchesType = selectedTypeId === null || p.type.id === selectedTypeId;
-        const matchesSearch =
-          !needle ||
-          p.name.toLowerCase().includes(needle) ||
-          p.address.line1?.toLowerCase().includes(needle) ||
-          p.address.line2?.toLowerCase().includes(needle) ||
-          p.address.city?.toLowerCase().includes(needle) ||
-          p.address.state?.toLowerCase().includes(needle) ||
-          p.address.postal?.toLowerCase().includes(needle);
-        return matchesType && matchesSearch;
-      }),
-    [needle, places, selectedTypeId],
-  );
+  const filteredPlaces = useMemo(() => {
+    const needle = searchText.toLowerCase().trim();
+
+    return places.filter((p) => {
+      const matchesType = selectedTypeId === null || p.type.id === selectedTypeId;
+      const matchesSearch =
+        !needle ||
+        p.name.toLowerCase().includes(needle) ||
+        p.address.line1?.toLowerCase().includes(needle) ||
+        p.address.line2?.toLowerCase().includes(needle) ||
+        p.address.city?.toLowerCase().includes(needle) ||
+        p.address.state?.toLowerCase().includes(needle) ||
+        p.address.postal?.toLowerCase().includes(needle);
+      return matchesType && matchesSearch;
+    });
+  }, [places, searchText, selectedTypeId]);
 
   const clearFilters = () => {
     setSelectedTypeId(null);


### PR DESCRIPTION
Implement a search filter to enable filtering places by various address fields, complementing the existing place type filter and resetting with the clear action. Enhance the filter section's responsive layout.

Relates to #96